### PR TITLE
Fix upload drop zone border to match design system default

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -18,7 +18,7 @@ Reference: `docs/design-system.md` for correct patterns.
 - **What:** Replace `border-white/15` with `border-white/10` everywhere in editor
 - **Files:** `src/components/editor/AddSectionUpload.tsx` and any others
 - **Test:** `grep -r "border-white/15" src/components/editor/` returns 0 results
-- **Status:** OPEN
+- **Status:** IN PROGRESS
 
 ### QR-03: Unify error message pattern
 - **What:** All error displays must use the standard error pill: `text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2`. Replace any inline red text, raw `text-red-400` without background, or other error formats.

--- a/src/components/editor/AddSectionUpload.tsx
+++ b/src/components/editor/AddSectionUpload.tsx
@@ -276,7 +276,7 @@ export function AddSectionUpload({
               ? "border-accent/40 bg-accent/5 cursor-wait"
               : dragOver
                 ? "border-accent bg-accent/10"
-                : "border-white/15 hover:border-white/30 hover:bg-white/5"
+                : "border-white/10 hover:border-white/30 hover:bg-white/5"
           }`}
         >
           {state === "processing" ? (


### PR DESCRIPTION
## What changed
The file upload drop zone had a non-standard `border-white/15` opacity. This updates it to `border-white/10`, which is the design system default for all quiet borders (dividers, cards, panels).

## Rubric item
QR-02: Normalize border opacity to white/10 default

## Files modified
- `src/components/editor/AddSectionUpload.tsx`
- `docs/quality-rubric.md` (marked IN PROGRESS)

## Verification
- Build: PASS
- Test: `grep -r "border-white/15" src/components/editor/` returns 0 results — PASS