### PR TITLE
Unify error messages to standard red pill style

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -24,7 +24,7 @@ Reference: `docs/design-system.md` for correct patterns.
 - **What:** All error displays must use the standard error pill: `text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2`. Replace any inline red text, raw `text-red-400` without background, or other error formats.
 - **Files:** All editor components showing errors
 - **Test:** Every `text-red-400` in editor components is inside a `bg-red-500/10` container
-- **Status:** OPEN
+- **Status:** IN PROGRESS
 
 ### QR-04: Unify button patterns to 3 types
 - **What:** Audit every `<button>` in editor components. Each must match one of: Primary (accent), Secondary (white/10), or Destructive (red-500/10). Fix any that don't match.

--- a/src/components/editor/AddSection.tsx
+++ b/src/components/editor/AddSection.tsx
@@ -301,7 +301,7 @@ export function AddSection({ documentTitle, documentSubtitle, onAdd, onAddMultip
             </div>
           )}
 
-          {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
+          {error && <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 mt-2">{error}</p>}
         </div>
       )}
     </div>

--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -223,9 +223,9 @@ function SectionImagePreview({
         </button>
       </div>
       {extractError && (
-        <div className="px-3 py-2 text-xs text-red-400 bg-red-500/5 border-t border-red-500/10">
+        <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 mx-3 mb-3">
           {extractError}
-        </div>
+        </p>
       )}
     </div>
   );

--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -118,7 +118,7 @@ export function LogoUpload({
           <X className="h-3 w-3" />
           {uploading ? "Removing..." : "Remove"}
         </button>
-        {error && <p className="text-xs text-red-400">{error}</p>}
+        {error && <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">{error}</p>}
       </div>
     );
   }
@@ -157,7 +157,7 @@ export function LogoUpload({
         )}
       </div>
 
-      {error && <p className="mt-1.5 text-xs text-red-400">{error}</p>}
+      {error && <p className="mt-1.5 text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">{error}</p>}
 
       <input
         ref={inputRef}


### PR DESCRIPTION
## What changed
Error messages in the editor that appeared as plain red text now show with a consistent background pill — a subtle red container with a border — making them easier to spot and visually consistent across all parts of the editor.

## Rubric item
QR-03: Unify error message pattern

## Files modified
- `src/components/editor/AddSection.tsx` — bare red text → standard error pill
- `src/components/editor/LogoUpload.tsx` — two bare red text instances → standard error pills
- `src/components/editor/EditableSectionRenderer.tsx` — near-miss pill (wrong opacity, border-only-top, no radius) → standard error pill

## Verification
- Build: PASS
- Test: `grep -r "text-red-400" src/components/editor/ | grep -v "bg-red-500/10|hover:text-red-400|text-red-400/60"` returns only 2 results — both are intentional non-error UI indicators (delete icon confirm state in SortableSectionList, character limit color in AddSectionPaste), not error message displays.