### PR TITLE
Add transition-colors to editor buttons missing hover animations

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -35,12 +35,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Manual audit — every button matches one of the 3 patterns in design-system.md
 - **Status:** OPEN
 
-### QR-05: Add transition-colors to all buttons
-- **Tier:** 0
-- **What:** Every `<button>` with a hover state must have `transition-colors`
-- **Files:** All files in `src/components/editor/`
-- **Test:** `grep -r "hover:bg-" src/components/editor/ | grep -v "transition"` returns 0 results for buttons
-- **Status:** OPEN
+### ~~QR-05: Add transition-colors to all buttons~~ DONE
+- **Status:** DONE — PR #5
 
 ### QR-21: Palette consistency audit — charts and active states should use Velocity palette
 - **Tier:** 1

--- a/src/components/editor/AddSection.tsx
+++ b/src/components/editor/AddSection.tsx
@@ -248,13 +248,13 @@ export function AddSection({ documentTitle, documentSubtitle, onAdd, onAddMultip
                   <div className="flex gap-2">
                     <button
                       onClick={() => handleGenerate(suggestedType)}
-                      className="px-3 py-1 rounded text-xs font-medium bg-accent text-white hover:bg-accent/80"
+                      className="px-3 py-1 rounded text-xs font-medium bg-accent text-white hover:bg-accent/80 transition-colors"
                     >
                       Generate
                     </button>
                     <button
                       onClick={() => { setSuggestedType(null); setStep("describe"); }}
-                      className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20"
+                      className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20 transition-colors"
                     >
                       Change type
                     </button>
@@ -281,19 +281,19 @@ export function AddSection({ documentTitle, documentSubtitle, onAdd, onAddMultip
               <div className="flex gap-2">
                 <button
                   onClick={() => { onAdd(generatedSection); handleBack(); }}
-                  className="px-3 py-1 rounded text-xs font-medium bg-green-600/20 text-green-400 hover:bg-green-600/30"
+                  className="px-3 py-1 rounded text-xs font-medium bg-green-600/20 text-green-400 hover:bg-green-600/30 transition-colors"
                 >
                   Keep
                 </button>
                 <button
                   onClick={handleBack}
-                  className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20"
+                  className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20 transition-colors"
                 >
                   Discard
                 </button>
                 <button
                   onClick={() => suggestedType && handleGenerate(suggestedType)}
-                  className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20"
+                  className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20 transition-colors"
                 >
                   Regenerate
                 </button>

--- a/src/components/editor/SectionEditorPanel.tsx
+++ b/src/components/editor/SectionEditorPanel.tsx
@@ -66,7 +66,7 @@ export function SectionEditorPanel({
                 setPendingRemap(null);
                 onPendingPreview?.(null);
               }}
-              className="px-3 py-1 rounded text-xs font-medium bg-green-600/20 text-green-400 hover:bg-green-600/30"
+              className="px-3 py-1 rounded text-xs font-medium bg-green-600/20 text-green-400 hover:bg-green-600/30 transition-colors"
             >
               Apply
             </button>
@@ -75,7 +75,7 @@ export function SectionEditorPanel({
                 setPendingRemap(null);
                 onPendingPreview?.(null);
               }}
-              className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20"
+              className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-muted-foreground hover:bg-white/20 transition-colors"
             >
               Cancel
             </button>


### PR DESCRIPTION
## What changed
Added `transition-colors` to 7 buttons in `AddSection.tsx` and `SectionEditorPanel.tsx` that had `hover:bg-*` states but were missing the transition class, causing abrupt color snaps on hover.

## Why
The design system requires `transition-colors` on every element with a hover color change. All other editor files already complied; these two files were the gap.

## Rubric item
QR-05 — Add transition-colors to all buttons

## Files modified
- `src/components/editor/AddSection.tsx` (5 buttons)
- `src/components/editor/SectionEditorPanel.tsx` (2 buttons)
- `docs/quality-rubric.md` (marked QR-05 DONE)

## Tier
**Tier 0** — Pure token change, zero behavior change. Adds smooth 150ms color transition on hover.