### PR TITLE
Add aria-label to all icon-only editor buttons

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -145,12 +145,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Screen reader announces save status changes and new chat messages
 - **Status:** OPEN
 
-### QR-15: ARIA labels on all icon-only buttons
-- **Tier:** 0
-- **What:** Every button that contains only an icon (no text) must have `aria-label`. Audit all editor components.
-- **Files:** All files in `src/components/editor/`
-- **Test:** `grep -r "className=.*w-[34].*h-[34]" src/components/editor/ | grep "<button"` — every match has `aria-label`
-- **Status:** OPEN
+### ~~QR-15: ARIA labels on all icon-only buttons~~ DONE
+- **Status:** DONE — PR #7
 
 ---
 

--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -78,6 +78,7 @@ export function AiChatPanel({
           {messages.length > 0 && (
             <button
               onClick={onClearHistory}
+              aria-label="Clear chat history"
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               title="Clear chat history"
             >
@@ -158,6 +159,7 @@ export function AiChatPanel({
           <button
             onClick={handleSend}
             disabled={!input.trim() || isLoading}
+            aria-label="Send message"
             className="p-2 text-muted-foreground hover:text-accent disabled:opacity-30 disabled:hover:text-muted-foreground transition-colors shrink-0"
           >
             <Send className="w-4 h-4" />

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -595,7 +595,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
             <div className="sticky top-0 z-20 mx-auto max-w-4xl px-6 pt-3">
               <div className="flex items-center gap-2 rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-2.5 text-sm text-red-400">
                 <span className="flex-1">{imageError}</span>
-                <button onClick={() => setImageError(null)} className="text-red-400/60 hover:text-red-400">
+                <button onClick={() => setImageError(null)} aria-label="Dismiss error" className="text-red-400/60 hover:text-red-400">
                   <XIcon className="w-4 h-4" />
                 </button>
               </div>

--- a/src/components/editor/ItemManager.tsx
+++ b/src/components/editor/ItemManager.tsx
@@ -60,6 +60,7 @@ function SortableRow({
       <button
         {...attributes}
         {...listeners}
+        aria-label="Drag to reorder item"
         className="mt-3 opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none"
         tabIndex={-1}
       >
@@ -69,6 +70,7 @@ function SortableRow({
       {canRemove && (
         <button
           onClick={onRemove}
+          aria-label="Remove item"
           className="mt-3 opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400 transition-opacity shrink-0"
           tabIndex={-1}
         >

--- a/src/components/editor/MobilePreviewSheet.tsx
+++ b/src/components/editor/MobilePreviewSheet.tsx
@@ -64,6 +64,7 @@ export function MobilePreviewSheet({
               <span className="text-sm font-medium">Preview</span>
               <button
                 onClick={onClose}
+                aria-label="Close preview"
                 className="text-muted-foreground hover:text-foreground transition-colors"
               >
                 <XIcon className="w-4 h-4" />

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -51,6 +51,7 @@ function InsertDivider({ onClick }: { onClick: () => void }) {
       <div className="absolute inset-x-3 h-px bg-transparent group-hover/insert:bg-accent/40 transition-colors" />
       <button
         onClick={onClick}
+        aria-label="Insert section here"
         className="relative mx-auto flex items-center justify-center w-5 h-5 rounded-full border border-transparent text-transparent group-hover/insert:border-accent/40 group-hover/insert:text-accent/70 hover:!border-accent hover:!text-accent hover:!bg-accent/10 transition-all"
       >
         <Plus className="w-3 h-3" />
@@ -102,6 +103,7 @@ function SortableItem({
       <button
         {...attributes}
         {...listeners}
+        aria-label="Drag to reorder section"
         className="opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none"
       >
         <GripVertical className="w-3.5 h-3.5" />
@@ -127,6 +129,7 @@ function SortableItem({
             setTimeout(() => setConfirmDelete(false), 2000);
           }
         }}
+        aria-label={confirmDelete ? "Confirm delete section" : "Delete section"}
         className={`flex items-center transition-opacity ${
           confirmDelete
             ? "opacity-100 text-red-400"

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -235,6 +235,7 @@ export function SplitViewLayout({
                   </div>
                   <button
                     onClick={handleCloseSidebarOverlay}
+                    aria-label="Close sidebar"
                     className="text-muted-foreground hover:text-foreground transition-colors"
                   >
                     <XIcon className="w-4 h-4" />


### PR DESCRIPTION
## What changed
Added `aria-label` attributes to 10 icon-only buttons across the editor that were accessible only as unlabeled clickable elements.

## Buttons fixed
| File | Button | aria-label |
|------|--------|------------|
| SortableSectionList | Insert divider (+) | `"Insert section here"` |
| SortableSectionList | Drag handle | `"Drag to reorder section"` |
| SortableSectionList | Delete (trash) | `"Delete section"` / `"Confirm delete section"` (dynamic) |
| MobilePreviewSheet | Close (X) | `"Close preview"` |
| ItemManager | Drag handle | `"Drag to reorder item"` |
| ItemManager | Remove (trash) | `"Remove item"` |
| AiChatPanel | Clear history | `"Clear chat history"` |
| AiChatPanel | Send | `"Send message"` |
| SplitViewLayout | Close sidebar (X) | `"Close sidebar"` |
| EditorLayout | Dismiss error (X) | `"Dismiss error"` |

## Not changed (already correct)
- `LogoUpload.tsx` remove button — has visible "Remove" text
- `EditableSectionRenderer.tsx` remove image — has visible "Remove image" text
- `DocumentSettings.tsx` reset colors — has visible "Reset" text
- Any button with a `title` attribute but visible text label

## Why
Icon-only buttons with no accessible name are WCAG 2.1 Level A failure (criterion 4.1.2). Screen reader users hear "button" with no context.

## Rubric item
QR-15 — ARIA labels on all icon-only buttons

## Tier
**Tier 0** — Pure attribute additions, zero behavior change.