### PR TITLE
Fix metric dashboard 4-item grid to balanced 2x2 layout

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -119,12 +119,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** /demo Section 5 "12-Month Rollout" — the Q3 2026 step (status: current) should visually stand out from the other steps (status: upcoming).
 - **Status:** OPEN
 
-### QR-23: Metric dashboard layout should handle 4-item case gracefully
-- **Tier:** 1
-- **What:** Revenue Model metric cards render as 3-up + 1 orphan on a second row. Either implement a 2x2 grid for 4 items or 4-across for lg screens.
-- **Files:** `src/components/viewer/sections/MetricDashboard.tsx`
-- **Test:** /demo Section 8 "Revenue Model" — four metric cards should lay out in a balanced grid, not 3+1.
-- **Status:** OPEN
+### ~~QR-23: Metric dashboard layout should handle 4-item case gracefully~~ DONE
+- **Status:** DONE — PR #9
 
 ### QR-24: Hub Diagram visual upgrade — currently just boxes + text list
 - **Tier:** 3

--- a/src/components/viewer/sections/MetricDashboard.tsx
+++ b/src/components/viewer/sections/MetricDashboard.tsx
@@ -130,7 +130,9 @@ export function MetricDashboard({
   const gridCols =
     metricCount <= 2
       ? "grid-cols-1 md:grid-cols-2"
-      : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
+      : metricCount === 4
+        ? "grid-cols-2 lg:grid-cols-4"
+        : "grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
 
   return (
     <div>


### PR DESCRIPTION
## What changed
Added an explicit 4-item case to the `MetricDashboard` grid logic so four cards render in a balanced 2×2 grid instead of 3+1.

## Before
```
≤2 items → md:grid-cols-2
3+ items → lg:grid-cols-3  ← 4 items falls here → 3+1 orphan
```

## After
```
≤2 items → md:grid-cols-2
4 items  → grid-cols-2 lg:grid-cols-4  ← new balanced case
3/5+ items → lg:grid-cols-3
```

On medium screens: 2×2 balanced grid. On large screens: 4-across single row.

## Why
A 3+1 layout looks unintentional and unpolished — the orphaned card stretches to full container width. This is an investor-facing surface and must pass the executive embarrassment test.

## Rubric item
QR-23 — Metric dashboard 4-item layout

## Files modified
- `src/components/viewer/sections/MetricDashboard.tsx`
- `docs/quality-rubric.md` (marked QR-23 DONE)

## Tier
**Tier 1** — Visual polish, no behavior change.