### PR TITLE
Use palette CSS variables in charts and sidebar active states

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -42,11 +42,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** `grep -r "hover:bg-" src/components/editor/ | grep -v "transition"` returns 0 results for buttons
 - **Status:** OPEN
 
-### QR-21: Palette consistency audit — charts and active states should use Velocity palette
-- **Tier:** 1
-- **What:** Audit components that render charts and highlights to ensure they prefer `--palette-accent1` through `--palette-accent5` over the default `--color-accent`. Currently the Market Sizing funnel chart renders default indigo bars even when the artifact has a custom `branding.palette`. Same for sidebar active-state highlight and the BOARD STRATEGY tag. Files to audit: `src/components/viewer/sections/DataVisualization.tsx`, `src/components/viewer/SidebarNav.tsx`, `src/components/viewer/sections/RichTextCollapsible.tsx`
-- **Test:** Open /demo (light theme, Velocity navy/teal palette). Funnel chart bars should be navy (`#1e3a5f`), not indigo. Sidebar active section should show navy highlight.
-- **Status:** OPEN
+### ~~QR-21: Palette consistency audit — charts and active states should use Velocity palette~~ DONE
+- **Status:** DONE — PR #10
 
 ---
 

--- a/src/components/viewer/SidebarNav.tsx
+++ b/src/components/viewer/SidebarNav.tsx
@@ -124,9 +124,10 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
                     className={cn(
                       "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-xs font-medium",
                       activeId === item.id
-                        ? "bg-accent text-white"
+                        ? "text-white"
                         : "bg-card text-muted"
                     )}
+                    style={activeId === item.id ? { backgroundColor: "var(--palette-accent1, var(--color-accent))" } : undefined}
                   >
                     {index + 1}
                   </span>
@@ -141,8 +142,9 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
         <div className="border-t border-border px-6 py-4">
           <div className="h-1.5 overflow-hidden rounded-full bg-card">
             <div
-              className="h-full rounded-full bg-accent transition-all duration-300"
+              className="h-full rounded-full transition-all duration-300"
               style={{
+                backgroundColor: "var(--palette-accent1, var(--color-accent))",
                 width: `${((items.findIndex((i) => i.id === activeId) + 1) / items.length) * 100}%`,
               }}
             />

--- a/src/components/viewer/sections/DataVisualization.tsx
+++ b/src/components/viewer/sections/DataVisualization.tsx
@@ -171,7 +171,8 @@ function BarChart({
               whileInView={{ height: `${height}%` }}
               transition={{ duration: 0.6, delay: index * 0.1, ease: "easeOut" }}
               viewport={{ once: true }}
-              className="w-full rounded-t-lg bg-accent min-h-[4px]"
+              className="w-full rounded-t-lg min-h-[4px]"
+              style={{ backgroundColor: "var(--palette-accent1, var(--color-accent))" }}
             />
             <span className="text-xs text-muted-foreground text-center truncate w-full">
               {item[xKey]}
@@ -224,8 +225,8 @@ function FunnelChart({
                 whileInView={{ width: `${width}%` }}
                 transition={{ duration: 0.6, delay: index * 0.1 }}
                 viewport={{ once: true }}
-                className="h-full rounded-lg bg-accent"
-                style={{ opacity: 1 - index * 0.12 }}
+                className="h-full rounded-lg"
+                style={{ backgroundColor: "var(--palette-accent1, var(--color-accent))", opacity: 1 - index * 0.12 }}
               />
             </div>
           </motion.div>


### PR DESCRIPTION
## What changed
Replaced hardcoded `bg-accent` (always indigo `#6366f1`) with `var(--palette-accent1, var(--color-accent))` in components that render prominent colored elements. When an artifact has a custom `branding.palette` (e.g., Velocity navy/teal), these elements now render in the correct brand color.

## Elements fixed
| Component | Element | Before | After |
|-----------|---------|--------|-------|
| `DataVisualization.tsx` | BarChart vertical bars | `bg-accent` | `var(--palette-accent1, ...)` |
| `DataVisualization.tsx` | FunnelChart horizontal bars | `bg-accent` | `var(--palette-accent1, ...)` |
| `SidebarNav.tsx` | Active section number badge | `bg-accent` | `var(--palette-accent1, ...)` |
| `SidebarNav.tsx` | Progress bar fill | `bg-accent` | `var(--palette-accent1, ...)` |

## Already correct (no change)
- `StaircaseChart` — already used `item.color ?? "var(--color-accent)"`
- `LayersChart` — same
- `RichTextCollapsible` tag — already used `var(--palette-accent1, var(--color-accent))`

## Fallback behavior
If no custom palette is set, `var(--palette-accent1)` is undefined, and the CSS `var()` fallback activates → uses `var(--color-accent)` (default indigo). Zero behavior change for documents without custom palettes.

## Rubric item
QR-21 — Palette consistency audit

## Tier
**Tier 1** — Visual polish, no behavior change for default palette.