### PR TITLE
Add hover bg and accent left border to sidebar section items

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -98,12 +98,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Visual check — editor panel clearly feels "primary," preview clearly feels "secondary"
 - **Status:** OPEN
 
-### QR-12: Consistent hover states on sidebar items
-- **Tier:** 1
-- **What:** All sidebar section items should have: hover bg-white/5, selected bg-accent/5 + left border accent, smooth transition
-- **Files:** `src/components/editor/SortableSectionList.tsx`, `SidebarRail.tsx`
-- **Test:** Hover over sidebar items — consistent highlight. Selected item has accent indicator.
-- **Status:** OPEN
+### ~~QR-12: Consistent hover states on sidebar items~~ DONE
+- **Status:** DONE — PR #11
 
 ### QR-13: Type selector dropdown polish
 - **Tier:** 1

--- a/src/components/editor/SidebarRail.tsx
+++ b/src/components/editor/SidebarRail.tsx
@@ -83,7 +83,7 @@ export function SidebarRail({
                 className={`relative w-full h-10 flex items-center justify-center transition-colors ${
                   isActive
                     ? "text-accent"
-                    : "text-muted-foreground hover:text-foreground"
+                    : "text-muted-foreground hover:bg-white/5 hover:text-foreground"
                 }`}
                 aria-label={`Section ${index + 1}: ${section.title || section.type}`}
                 title={section.title || `Section ${index + 1}`}

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -93,10 +93,10 @@ function SortableItem({
       ref={setNodeRef}
       style={style}
       onClick={onSelect}
-      className={`group flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer transition-colors ${
+      className={`group flex items-center gap-2 pl-2 pr-3 py-2 rounded-lg cursor-pointer transition-colors border-l-2 ${
         isSelected
-          ? "bg-white/10 text-foreground"
-          : "text-muted-foreground hover:bg-white/5 hover:text-foreground"
+          ? "bg-accent/5 text-foreground border-accent"
+          : "text-muted-foreground hover:bg-white/5 hover:text-foreground border-transparent"
       }`}
     >
       <button


### PR DESCRIPTION
## What changed
Standardized hover and selected states across both sidebar components.

### SortableSectionList
- **Selected:** `bg-white/10` → `bg-accent/5 border-l-2 border-accent` (clear visual anchor)
- **Unselected:** Added `border-l-2 border-transparent` (prevents 2px layout shift when selecting)
- **Hover:** `hover:bg-white/5` unchanged — already correct

### SidebarRail (icon rail)
- Added `hover:bg-white/5` to icon buttons — previously only changed text color on hover, no background feedback

## Why
The selected state was `bg-white/10` which is subtle and identical to a hover state on a nearby element. The accent left border makes the active section unambiguous at a glance — standard pattern in sidebar navigation.

## Rubric item
QR-12 — Consistent hover states on sidebar items

## Files modified
- `src/components/editor/SortableSectionList.tsx`
- `src/components/editor/SidebarRail.tsx`
- `docs/quality-rubric.md`

## Tier
**Tier 1** — Visual polish, no behavior change.