### PR TITLE
Add bg-surface to editor panel for primary/secondary visual hierarchy

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -91,12 +91,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 ## Priority 3: Visual Hierarchy & Polish
 
-### QR-11: Split view visual hierarchy
-- **Tier:** 1
-- **What:** Editor panel (left) should feel like the primary workspace. Preview panel (right) should feel like a reference. Add subtle visual differentiation: editor gets full-opacity background, preview gets slightly muted (`bg-background/50` — already partially done).
-- **Files:** `src/components/editor/SplitViewLayout.tsx`, `SectionPreviewPanel.tsx`
-- **Test:** Visual check — editor panel clearly feels "primary," preview clearly feels "secondary"
-- **Status:** OPEN
+### ~~QR-11: Split view visual hierarchy~~ DONE
+- **Status:** DONE — PR #12
 
 ### QR-12: Consistent hover states on sidebar items
 - **Tier:** 1

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -174,8 +174,8 @@ export function SplitViewLayout({
         onExpandSidebar={handleExpandSidebar}
       />
 
-      {/* Editor Panel (left ~50%) */}
-      <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
+      {/* Editor Panel (left ~50%) — primary workspace, slightly elevated */}
+      <div className="flex-1 min-w-0 flex flex-col overflow-hidden bg-surface">
         <SectionEditorPanel
           section={selectedSection}
           sectionIndex={selectedSectionIndex}


### PR DESCRIPTION
## What changed
Added `bg-surface` (`#12141d`) to the editor panel wrapper in `SplitViewLayout.tsx`.

## Before/After
| Panel | Before | After |
|-------|--------|-------|
| Editor (left) | No background (inherits `#0a0b10`) | `bg-surface` (`#12141d`) — slightly elevated |
| Preview (right) | `bg-background/50` (already done) | Unchanged |

## Effect
The editor panel is now visually distinct as the primary workspace. The slight elevation (`#12141d` vs `#0a0b10`) creates a clear primary/secondary relationship without being heavy-handed.

## Why
Both panels looked identical — there was no visual cue that the editor was the "active" side. The preview panel already had `bg-background/50` from a previous commit, but the editor had no counterpart differentiation.

## Rubric item
QR-11 — Split view visual hierarchy

## Files modified
- `src/components/editor/SplitViewLayout.tsx`
- `docs/quality-rubric.md`

## Tier
**Tier 1** — Visual polish, no behavior change.