### PR TITLE
Show filename and file size during upload processing

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -59,12 +59,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Click delete, wait 10 seconds — "Confirm?" still visible. Press Escape — cancels. Click confirm — deletes.
 - **Status:** OPEN
 
-### QR-07: Add loading states to Upload tab
-- **Tier:** 1
-- **What:** Upload tab should show: (1) file name while processing, (2) progress stage text that updates ("Extracting text..." → "Structuring content..."), (3) file size
-- **Files:** `src/components/editor/AddSectionUpload.tsx`
-- **Test:** Upload a PDF — see filename, size, and stage text update during processing
-- **Status:** OPEN
+### ~~QR-07: Add loading states to Upload tab~~ DONE
+- **Status:** DONE — PR #13
 
 ### QR-08: Add empty state to AI chat panel
 - **Tier:** 2

--- a/src/components/editor/AddSectionUpload.tsx
+++ b/src/components/editor/AddSectionUpload.tsx
@@ -29,8 +29,15 @@ export function AddSectionUpload({
   const [error, setError] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const [statusText, setStatusText] = useState("");
+  const [uploadFile, setUploadFile] = useState<{ name: string; size: string } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+
+  const formatFileSize = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
 
   const getEditKeyParam = useCallback(() => {
     const urlKey = new URLSearchParams(window.location.search).get("key");
@@ -176,6 +183,7 @@ export function AddSectionUpload({
       }
 
       setState("processing");
+      setUploadFile({ name: file.name, size: formatFileSize(file.size) });
       const controller = new AbortController();
       abortRef.current = controller;
 
@@ -237,6 +245,7 @@ export function AddSectionUpload({
     }
     setState("idle");
     setStatusText("");
+    setUploadFile(null);
   }, []);
 
   // Review mode — reuse MultiSectionReview
@@ -282,6 +291,12 @@ export function AddSectionUpload({
           {state === "processing" ? (
             <>
               <Loader2 className="w-8 h-8 text-accent animate-spin" />
+              {uploadFile && (
+                <p className="text-xs font-medium text-foreground/80 text-center truncate max-w-full">
+                  {uploadFile.name}
+                  <span className="text-muted-foreground font-normal ml-1.5">· {uploadFile.size}</span>
+                </p>
+              )}
               <p className="text-sm text-muted-foreground text-center">
                 {statusText}
               </p>


### PR DESCRIPTION
## What changed
The upload tab now shows the filename and file size while processing, so users know which file is being worked on.

## Before
Processing state: spinner + stage text only

## After
Processing state:
1. **Spinner** (unchanged)
2. **Filename + size** — `"my-strategy.pdf · 2.3 MB"` (new)
3. **Stage text** — already updating: `"Extracting text..."` → `"Structuring 12 pages..."` (unchanged)

## Implementation
- Added `uploadFile` state: `{ name: string; size: string }`
- Added `formatFileSize()` helper (B/KB/MB)
- State set when processing begins (`handleFile`), cleared on cancel/error

## Why
Uploading a 10MB PDF takes 15-30 seconds. Without the filename, users have no confirmation that the right file was selected. The size hint tells them whether it will take 5s or 30s.

## Rubric item
QR-07 — Add loading states to Upload tab

## Files modified
- `src/components/editor/AddSectionUpload.tsx`
- `docs/quality-rubric.md`

## Tier
**Tier 1** — Visual polish, no behavior change.