### PR TITLE
Unify green confirm buttons to standard accent primary pattern (QR-04)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -28,12 +28,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Every `text-red-400` in editor components is inside a `bg-red-500/10` container
 - **Status:** IN PROGRESS
 
-### QR-04: Unify button patterns to 3 types
-- **Tier:** 1
-- **What:** Audit every `<button>` in editor components. Each must match one of: Primary (accent), Secondary (white/10), or Destructive (red-500/10). Fix any that don't match.
-- **Files:** All files in `src/components/editor/`
-- **Test:** Manual audit — every button matches one of the 3 patterns in design-system.md
-- **Status:** OPEN
+### ~~QR-04: Unify button patterns to 3 types~~ DONE
+- **Status:** DONE — PR #18. Fixed Apply (SectionEditorPanel), Keep (AddSection), Add Selected (MultiSectionReview) — all changed from non-standard green to Primary accent. TopBar publish toggle uses green as a status indicator (published=live), which is intentional semantic colour; left as-is (would require Tier 2 design decision).
 
 ### ~~QR-05: Add transition-colors to all buttons~~ DONE
 - **Status:** DONE — PR #5
@@ -176,6 +172,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 - **QR-01: Kill non-standard text sizes** — PR #1, merged 2026-04-04
 - **QR-02: Normalize border opacity to white/10 default** — PR #2, merged 2026-04-04
+- **QR-04: Unify button patterns to 3 types** — PR #18, 2026-04-04
 
 ---
 

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -29,7 +29,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Status:** IN PROGRESS
 
 ### ~~QR-04: Unify button patterns to 3 types~~ DONE
-- **Status:** DONE — PR #18. Fixed Apply (SectionEditorPanel), Keep (AddSection), Add Selected (MultiSectionReview) — all changed from non-standard green to Primary accent. TopBar publish toggle uses green as a status indicator (published=live), which is intentional semantic colour; left as-is (would require Tier 2 design decision).
+- **Status:** DONE — PR #15. Fixed Apply (SectionEditorPanel), Keep (AddSection), Add Selected (MultiSectionReview) — all changed from non-standard green to Primary accent. TopBar publish toggle uses green as a status indicator (published=live), which is intentional semantic colour; left as-is (would require Tier 2 design decision).
 
 ### ~~QR-05: Add transition-colors to all buttons~~ DONE
 - **Status:** DONE — PR #5
@@ -172,7 +172,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 - **QR-01: Kill non-standard text sizes** — PR #1, merged 2026-04-04
 - **QR-02: Normalize border opacity to white/10 default** — PR #2, merged 2026-04-04
-- **QR-04: Unify button patterns to 3 types** — PR #18, 2026-04-04
+- **QR-04: Unify button patterns to 3 types** — PR #15, 2026-04-04
 
 ---
 

--- a/src/components/editor/AddSection.tsx
+++ b/src/components/editor/AddSection.tsx
@@ -281,7 +281,7 @@ export function AddSection({ documentTitle, documentSubtitle, onAdd, onAddMultip
               <div className="flex gap-2">
                 <button
                   onClick={() => { onAdd(generatedSection); handleBack(); }}
-                  className="px-3 py-1 rounded text-xs font-medium bg-green-600/20 text-green-400 hover:bg-green-600/30 transition-colors"
+                  className="px-3 py-1 rounded text-xs font-medium bg-accent text-white hover:bg-accent/80 transition-colors"
                 >
                   Keep
                 </button>

--- a/src/components/editor/MultiSectionReview.tsx
+++ b/src/components/editor/MultiSectionReview.tsx
@@ -126,7 +126,7 @@ export function MultiSectionReview({
             onConfirm(sections.filter((s) => selected.has(s.id)))
           }
           disabled={selectedCount === 0}
-          className="w-full px-3 py-2 rounded-lg text-sm font-medium bg-green-600/20 text-green-400 hover:bg-green-600/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          className="w-full px-3 py-2 rounded-lg text-sm font-medium bg-accent text-white hover:bg-accent/80 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         >
           Add {selectedCount} Selected
         </button>

--- a/src/components/editor/SectionEditorPanel.tsx
+++ b/src/components/editor/SectionEditorPanel.tsx
@@ -66,7 +66,7 @@ export function SectionEditorPanel({
                 setPendingRemap(null);
                 onPendingPreview?.(null);
               }}
-              className="px-3 py-1 rounded text-xs font-medium bg-green-600/20 text-green-400 hover:bg-green-600/30 transition-colors"
+              className="px-3 py-1 rounded text-xs font-medium bg-accent text-white hover:bg-accent/80 transition-colors"
             >
               Apply
             </button>


### PR DESCRIPTION
## What

Converts non-standard green button variant to the standard Primary button pattern on three confirm action buttons:
- **Keep** button in AddSection.tsx
- **Apply** button in SectionEditorPanel.tsx
- **Add Selected** button in MultiSectionReview.tsx

Before: `bg-green-600/20 text-green-400 hover:bg-green-600/30`
After: `bg-accent text-white hover:bg-accent/80 transition-colors`

## Why

QR-04: All confirm/primary actions should use the standard Primary button pattern. The green variant was inconsistent with the design system.

Note: TopBar Published/Draft toggle intentionally left green -- it is a semantic status indicator, not an action button.

## Tier

Tier 1 -- Visual polish, no behavior change.

## Files Modified
- `src/components/editor/AddSection.tsx`
- `src/components/editor/SectionEditorPanel.tsx`
- `src/components/editor/MultiSectionReview.tsx`
- `docs/quality-rubric.md` (marked QR-04 DONE)