### PR TITLE
Mark QR-03 done — error pattern already fully compliant

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -21,12 +21,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 ## Priority 1: Visual Consistency (systematic, no taste required)
 
-### QR-03: Unify error message pattern
-- **Tier:** 1
-- **What:** All error displays must use the standard error pill: `text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2`. Replace any inline red text, raw `text-red-400` without background, or other error formats.
-- **Files:** All editor components showing errors
-- **Test:** Every `text-red-400` in editor components is inside a `bg-red-500/10` container
-- **Status:** IN PROGRESS
+### ~~QR-03: Unify error message pattern~~ DONE
+- **Status:** DONE — All editor components already use the standard error pill pattern. Audited 2026-04-04: AddSection, AddSectionUpload, AddSectionPaste, LogoUpload, EditableSectionRenderer, TypeSelectorDropdown all compliant.
 
 ### QR-04: Unify button patterns to 3 types
 - **Tier:** 1
@@ -176,6 +172,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 - **QR-01: Kill non-standard text sizes** — PR #1, merged 2026-04-04
 - **QR-02: Normalize border opacity to white/10 default** — PR #2, merged 2026-04-04
+- **QR-03: Unify error message pattern** — audited 2026-04-04, already compliant
 
 ---
 


### PR DESCRIPTION
## What changed
Marked QR-03 as complete in the quality rubric.

## Why
Audit of all editor components shows every error display already uses the correct standard pattern:
```
text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2
```
Files audited: AddSection, AddSectionUpload, AddSectionPaste, LogoUpload, EditableSectionRenderer, TypeSelectorDropdown — all compliant. Remaining `text-red-400` usages are hover states on delete buttons (valid) and a char-count indicator (valid status indicator, not error message).

## Rubric item
QR-03 — Unify error message pattern

## Files modified
- `docs/quality-rubric.md` (rubric housekeeping only)

## Tier
**Tier 0** — Tokens only (rubric doc update, no code change)