### PR TITLE
Add aria-label to all icon-only buttons in editor components

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -118,12 +118,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Screen reader announces save status changes and new chat messages
 - **Status:** OPEN
 
-### QR-15: ARIA labels on all icon-only buttons
-- **Tier:** 0
-- **What:** Every button that contains only an icon (no text) must have `aria-label`. Audit all editor components.
-- **Files:** All files in `src/components/editor/`
-- **Test:** `grep -r "className=.*w-[34].*h-[34]" src/components/editor/ | grep "<button"` — every match has `aria-label`
-- **Status:** OPEN
+### ~~QR-15: ARIA labels on all icon-only buttons~~ DONE
+- **Status:** DONE — PR #20. Added aria-label to: AiChatPanel clear-history (RotateCcw) and send (Send) buttons; SortableSectionList drag handle (GripVertical), delete (Trash2), insert (Plus); SplitViewLayout close sidebar (X); EditorLayout dismiss error (X); ItemManager drag handle (GripVertical) and remove (Trash2).
 
 ---
 
@@ -176,6 +172,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 - **QR-01: Kill non-standard text sizes** — PR #1, merged 2026-04-04
 - **QR-02: Normalize border opacity to white/10 default** — PR #2, merged 2026-04-04
+- **QR-15: ARIA labels on all icon-only buttons** — PR #20, 2026-04-04
 
 ---
 

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -119,7 +119,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Status:** OPEN
 
 ### ~~QR-15: ARIA labels on all icon-only buttons~~ DONE
-- **Status:** DONE — PR #20. Added aria-label to: AiChatPanel clear-history (RotateCcw) and send (Send) buttons; SortableSectionList drag handle (GripVertical), delete (Trash2), insert (Plus); SplitViewLayout close sidebar (X); EditorLayout dismiss error (X); ItemManager drag handle (GripVertical) and remove (Trash2).
+- **Status:** DONE — PR #18. Added aria-label to: AiChatPanel clear-history (RotateCcw) and send (Send) buttons; SortableSectionList drag handle (GripVertical), delete (Trash2), insert (Plus); SplitViewLayout close sidebar (X); EditorLayout dismiss error (X); ItemManager drag handle (GripVertical) and remove (Trash2).
 
 ---
 
@@ -172,7 +172,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 - **QR-01: Kill non-standard text sizes** — PR #1, merged 2026-04-04
 - **QR-02: Normalize border opacity to white/10 default** — PR #2, merged 2026-04-04
-- **QR-15: ARIA labels on all icon-only buttons** — PR #20, 2026-04-04
+- **QR-15: ARIA labels on all icon-only buttons** — PR #18, 2026-04-04
 
 ---
 

--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -80,6 +80,7 @@ export function AiChatPanel({
               onClick={onClearHistory}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               title="Clear chat history"
+              aria-label="Clear chat history"
             >
               <RotateCcw className="w-3 h-3" />
             </button>
@@ -159,6 +160,7 @@ export function AiChatPanel({
             onClick={handleSend}
             disabled={!input.trim() || isLoading}
             className="p-2 text-muted-foreground hover:text-accent disabled:opacity-30 disabled:hover:text-muted-foreground transition-colors shrink-0"
+            aria-label="Send message"
           >
             <Send className="w-4 h-4" />
           </button>

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -595,7 +595,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
             <div className="sticky top-0 z-20 mx-auto max-w-4xl px-6 pt-3">
               <div className="flex items-center gap-2 rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-2.5 text-sm text-red-400">
                 <span className="flex-1">{imageError}</span>
-                <button onClick={() => setImageError(null)} className="text-red-400/60 hover:text-red-400">
+                <button onClick={() => setImageError(null)} className="text-red-400/60 hover:text-red-400" aria-label="Dismiss error">
                   <XIcon className="w-4 h-4" />
                 </button>
               </div>

--- a/src/components/editor/ItemManager.tsx
+++ b/src/components/editor/ItemManager.tsx
@@ -62,6 +62,7 @@ function SortableRow({
         {...listeners}
         className="mt-3 opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none"
         tabIndex={-1}
+        aria-label="Drag to reorder"
       >
         <GripVertical className="w-3.5 h-3.5" />
       </button>
@@ -71,6 +72,7 @@ function SortableRow({
           onClick={onRemove}
           className="mt-3 opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400 transition-opacity shrink-0"
           tabIndex={-1}
+          aria-label="Remove item"
         >
           <Trash2 className="w-3.5 h-3.5" />
         </button>

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -52,6 +52,7 @@ function InsertDivider({ onClick }: { onClick: () => void }) {
       <button
         onClick={onClick}
         className="relative mx-auto flex items-center justify-center w-5 h-5 rounded-full border border-transparent text-transparent group-hover/insert:border-accent/40 group-hover/insert:text-accent/70 hover:!border-accent hover:!text-accent hover:!bg-accent/10 transition-all"
+        aria-label="Insert section here"
       >
         <Plus className="w-3 h-3" />
       </button>
@@ -103,6 +104,7 @@ function SortableItem({
         {...attributes}
         {...listeners}
         className="opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none"
+        aria-label="Drag to reorder"
       >
         <GripVertical className="w-3.5 h-3.5" />
       </button>
@@ -132,6 +134,7 @@ function SortableItem({
             ? "opacity-100 text-red-400"
             : "opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400"
         }`}
+        aria-label={confirmDelete ? "Confirm delete section" : "Delete section"}
       >
         <Trash2 className="w-3.5 h-3.5" />
         {confirmDelete && <span className="text-xs ml-1">confirm?</span>}

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -236,6 +236,7 @@ export function SplitViewLayout({
                   <button
                     onClick={handleCloseSidebarOverlay}
                     className="text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Close sidebar"
                   >
                     <XIcon className="w-4 h-4" />
                   </button>


### PR DESCRIPTION
## What changed
Every button containing only an icon now has an aria-label so screen readers can announce its purpose.

## Why
QR-15 requires every icon-only button to have aria-label. Previously 8 buttons had no accessible name.

## Files modified
- AiChatPanel.tsx: clear-history (RotateCcw) and send (Send) buttons
- SortableSectionList.tsx: drag handle, delete (with dynamic confirm state label), insert
- SplitViewLayout.tsx: close sidebar (X) button
- EditorLayout.tsx: dismiss image error (X) button
- ItemManager.tsx: drag handle and remove item buttons
- docs/quality-rubric.md: rubric housekeeping

## Rubric item
QR-15 — ARIA labels on all icon-only buttons

## Tier
Tier 0 — Accessibility tokens only, zero behavior change