### PR TITLE
Normalize text-[9px] to text-[10px] in GuidedJourney viewer

### DIFF
--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -347,7 +347,7 @@ function TimelineTrack({
                     </span>
                     <span
                       className={cn(
-                        "mt-0.5 max-w-[80px] text-center text-[9px] leading-tight transition-colors whitespace-nowrap",
+                        "mt-0.5 max-w-[80px] text-center text-[10px] leading-tight transition-colors whitespace-nowrap",
                         isActive
                           ? "font-semibold"
                           : "text-muted opacity-50"


### PR DESCRIPTION
## What changed
One remaining text-[9px] usage in GuidedJourney.tsx normalized to text-[10px].

## Why
text-[9px] is on the design-system kill list. The minimum allowed text size is text-[10px] for labels and metadata.

## Discovery
Off-rubric find during discovery loop. All editor components were previously normalized (QR-01), but this viewer component was missed.

## Files modified
- src/components/viewer/sections/GuidedJourney.tsx:350

## Design-system reference
Typography scale — Kill list: text-[9px] normalize to text-[10px]

## Tier
Tier 0 — Token only, zero behavior change