### PR TITLE
Normalize disabled:opacity-50 to disabled:opacity-30 in editor buttons

### DIFF
--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -204,7 +204,7 @@ function SectionImagePreview({
           <button
             onClick={handleExtractStructure}
             disabled={isExtracting}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           >
             {isExtracting ? (
               <Loader2 className="w-3 h-3 animate-spin" />

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -535,7 +535,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                       <button
                         onClick={() => fileInputRef.current?.click()}
                         disabled={isProcessingImage}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                       >
                         <ImageIcon className="w-4 h-4" />
                         {isProcessingImage ? "Processing..." : "Add from Image"}

--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -113,7 +113,7 @@ export function LogoUpload({
         <button
           onClick={handleRemove}
           disabled={uploading}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         >
           <X className="h-3 w-3" />
           {uploading ? "Removing..." : "Remove"}

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -313,7 +313,7 @@ export function SplitViewLayout({
                           handleCloseSidebarOverlay();
                         }}
                         disabled={isProcessingImage}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                       >
                         <ImageIcon className="w-4 h-4" />
                         {isProcessingImage ? "Processing..." : "Add from Image"}

--- a/src/components/editor/TypeSelectorDropdown.tsx
+++ b/src/components/editor/TypeSelectorDropdown.tsx
@@ -119,7 +119,7 @@ export function TypeSelectorDropdown({
       <button
         onClick={() => !isLoading && setIsOpen((v) => !v)}
         disabled={isLoading}
-        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
       >
         {isLoading ? (
           <>


### PR DESCRIPTION
## What changed
5 editor buttons were using disabled:opacity-50. Normalized to disabled:opacity-30 disabled:cursor-not-allowed per design system.

## Why
design-system.md Buttons — Disabled State: disabled:opacity-30 disabled:cursor-not-allowed

## Files modified
- src/components/editor/SplitViewLayout.tsx
- src/components/editor/EditorLayout.tsx
- src/components/editor/EditableSectionRenderer.tsx
- src/components/editor/TypeSelectorDropdown.tsx
- src/components/editor/LogoUpload.tsx

## Discovery
Off-rubric find during discovery loop.

## Tier
Tier 0 — Token only (opacity value change, no behavior change)