### PR TITLE
Remove unused imports across 3 files

### DIFF
--- a/src/app/[slug]/opengraph-image.tsx
+++ b/src/app/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { getArtifactBySlug, getArtifactForEdit } from "@/lib/artifacts/actions";
+import { getArtifactForEdit } from "@/lib/artifacts/actions";
 
 export const runtime = "edge";
 export const alt = "Strata — Interactive Strategy Artifact";

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -13,7 +13,6 @@ import {
   RotateCcw,
   Upload,
   FileText,
-  X,
 } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";

--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import type { Section, SectionType } from "@/types/artifact";
-import type { ChatMessage, ChatSuggestion, ChatScope } from "@/hooks/useAiChat";
+import type { SectionType } from "@/types/artifact";
+import type { ChatMessage, ChatScope } from "@/hooks/useAiChat";
 import { getQuickChips } from "@/hooks/useAiChat";
 import { Sparkles, Send, Loader2, Check, X, RotateCcw } from "lucide-react";
 


### PR DESCRIPTION
## What changed
Removed 4 unused imports that were generating lint warnings.

- AiChatPanel.tsx: Section, ChatSuggestion type imports
- opengraph-image.tsx: getArtifactBySlug
- create/page.tsx: X icon from lucide-react

## Discovery
Off-rubric find during lint sweep.

## Tier
Tier 0 — Tokens only, zero behavior change