### PR TITLE
Replace fragile delete timeout with persistent confirmation (QR-06)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -41,12 +41,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 ## Priority 2: Interaction Completeness (4-state rule)
 
-### QR-06: Delete confirmation is too fragile
-- **Tier:** 2
-- **What:** Current delete uses a 2-second timeout that resets if you hover away. Replace with a proper confirmation: click delete → button changes to "Confirm delete?" (red, stays until clicked or Escape)
-- **Files:** `src/components/editor/SortableSectionList.tsx`
-- **Test:** Click delete, wait 10 seconds — "Confirm?" still visible. Press Escape — cancels. Click confirm — deletes.
-- **Status:** OPEN
+### ~~QR-06: Delete confirmation is too fragile~~ DONE
+- **Status:** DONE — PR opened 2026-04-04. Replaced 2s timeout with persistent "Confirm delete?" pill (Escape to cancel).
 
 ### ~~QR-07: Add loading states to Upload tab~~ DONE
 - **Status:** DONE — PR #13

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -16,7 +16,7 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Section } from "@/types/artifact";
 import { SECTION_TYPE_LABELS } from "@/types/artifact";
 import { GripVertical, Plus, Trash2 } from "lucide-react";
@@ -83,6 +83,15 @@ function SortableItem({
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: section.id });
 
+  useEffect(() => {
+    if (!confirmDelete) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setConfirmDelete(false);
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [confirmDelete]);
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -117,6 +126,7 @@ function SortableItem({
         </p>
       </div>
       <button
+        aria-label={confirmDelete ? "Confirm delete" : "Delete section"}
         onClick={(e) => {
           e.stopPropagation();
           if (confirmDelete) {
@@ -124,17 +134,16 @@ function SortableItem({
             setConfirmDelete(false);
           } else {
             setConfirmDelete(true);
-            setTimeout(() => setConfirmDelete(false), 2000);
           }
         }}
-        className={`flex items-center transition-opacity ${
+        className={`flex items-center gap-1 rounded px-1.5 py-0.5 transition-all ${
           confirmDelete
-            ? "opacity-100 text-red-400"
-            : "opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400"
+            ? "opacity-100 bg-red-500/10 text-red-400 border border-red-500/20"
+            : "opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400 border border-transparent"
         }`}
       >
-        <Trash2 className="w-3.5 h-3.5" />
-        {confirmDelete && <span className="text-xs ml-1">confirm?</span>}
+        <Trash2 className="w-3.5 h-3.5 shrink-0" />
+        {confirmDelete && <span className="text-xs whitespace-nowrap">Confirm delete?</span>}
       </button>
     </div>
   );


### PR DESCRIPTION
## What changed
Replaced the 2-second auto-dismiss delete confirmation with a persistent "Confirm delete?" pill that stays visible until the user explicitly confirms or presses Escape.

## Why
The 2-second timeout is unreliable — it vanishes before slow readers can act, and there's no keyboard way to cancel. The new pattern matches standard destructive action UX.

## Behavior
- Click trash icon → button transforms into a red pill reading "Confirm delete?" (uses `bg-red-500/10 border-red-500/20` — standard error pill pattern)
- Stays visible indefinitely until confirmed or dismissed
- Press **Escape** anywhere to cancel
- Click confirmed → section deleted, state resets
- `aria-label` updates dynamically: "Delete section" / "Confirm delete"

## Rubric item
QR-06 | Priority 2: Interaction Completeness

## Files modified
- `src/components/editor/SortableSectionList.tsx`

## Tier
**Tier 2** — visible UX behavior change. Held for Jon's review.