### PR TITLE
Enhance AI chat empty state with contextual quick-start prompts (QR-08)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -51,12 +51,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 ### ~~QR-07: Add loading states to Upload tab~~ DONE
 - **Status:** DONE — PR #13
 
-### QR-08: Add empty state to AI chat panel
-- **Tier:** 2
-- **What:** Current empty state is just text. Add: Sparkles icon (already there), 2-3 contextual quick-start prompts based on current section type, subtle visual treatment
-- **Files:** `src/components/editor/AiChatPanel.tsx`
-- **Test:** Open AI tab with no messages — see icon + quick-start suggestions
-- **Status:** OPEN
+### ~~QR-08: Add empty state to AI chat panel~~ DONE
+- **Status:** DONE — PR opened 2026-04-04. Enhanced empty state with accent icon container, section-type-specific prompt suggestions as full-width clickable rows; bottom chip strip hidden until conversation starts.
 
 ### QR-09: Add section duplicate action
 - **Tier:** 2

--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -90,14 +90,27 @@ export function AiChatPanel({
       {/* Message list */}
       <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3">
         {messages.length === 0 && !isLoading && (
-          <div className="text-center py-8">
-            <Sparkles className="w-6 h-6 text-accent/40 mx-auto mb-2" />
-            <p className="text-xs text-muted-foreground">
-              Ask the AI co-editor to refine your content.
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              It can ask clarifying questions before making changes.
-            </p>
+          <div className="py-6 px-1">
+            <div className="text-center mb-5">
+              <div className="w-9 h-9 rounded-full bg-accent/10 flex items-center justify-center mx-auto mb-3">
+                <Sparkles className="w-4 h-4 text-accent/70" />
+              </div>
+              <p className="text-xs font-medium text-foreground/80">AI co-editor</p>
+              <p className="text-[10px] text-muted-foreground mt-0.5">
+                Describe what to change — it asks before rewriting.
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              {chips.map((chip) => (
+                <button
+                  key={chip.label}
+                  onClick={() => onSend(chip.instruction)}
+                  className="w-full text-left px-3 py-2 rounded-lg text-xs bg-white/5 text-muted-foreground hover:bg-white/10 hover:text-foreground border border-white/10 hover:border-white/20 transition-all"
+                >
+                  {chip.label}
+                </button>
+              ))}
+            </div>
           </div>
         )}
 
@@ -128,8 +141,8 @@ export function AiChatPanel({
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Quick-action chips */}
-      {!isLoading && (
+      {/* Quick-action chips — only shown when a conversation is in progress */}
+      {!isLoading && messages.length > 0 && (
         <div className="px-3 pb-2 flex flex-wrap gap-1.5">
           {chips.map((chip) => (
             <button


### PR DESCRIPTION
## What changed
Replaced the minimal text-only empty state in the AI chat panel with a more useful onboarding experience.

## Why
The old empty state (icon + two generic text lines) gave no signal about what to do first. Users had to discover the quick-action chips by scrolling down. This surfaces them immediately when the tab opens.

## Behavior
- Empty state now shows: accent icon container + "AI co-editor" label + one-liner description
- Section-type-specific prompts shown as full-width clickable rows (uses same `getQuickChips()` data as before)
- Bottom chip strip now hidden until a conversation is started (prevents showing prompts in two places)
- Once messages exist, strip reappears at the bottom as before

## Rubric item
QR-08 | Priority 2: Interaction Completeness

## Files modified
- `src/components/editor/AiChatPanel.tsx`

## Tier
**Tier 2** — visible UX change. Held for Jon's review.