### PR TITLE
Add section duplicate action to sidebar list (QR-09)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -58,12 +58,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Open AI tab with no messages — see icon + quick-start suggestions
 - **Status:** OPEN
 
-### QR-09: Add section duplicate action
-- **Tier:** 2
-- **What:** Each section in the sidebar list should have a "Duplicate" action (copy icon) alongside delete. Creates exact copy with new ID, inserted below.
-- **Files:** `src/components/editor/SortableSectionList.tsx`, parent editor component
-- **Test:** Click duplicate on any section — new identical section appears below with "(Copy)" suffix on title
-- **Status:** OPEN
+### ~~QR-09: Add section duplicate action~~ DONE
+- **Status:** DONE — PR opened 2026-04-04. Copy icon on each section row (hidden until hover); creates deep copy with new ID and "(Copy)" title suffix, inserted immediately below.
 
 ### QR-10: Keyboard shortcut discoverability
 - **Tier:** 2

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -417,6 +417,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                 editor.updateSection(sectionId, () => updated)
               }
               onDeleteSection={editor.deleteSection}
+              onDuplicateSection={editor.duplicateSection}
               onReorderSections={editor.reorderSections}
               onAddSection={editor.addSection}
               onAddSections={editor.addSections}
@@ -517,6 +518,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                         selectedSectionId={editor.selectedSectionId}
                         onSelect={editor.setSelectedSectionId}
                         onDelete={editor.deleteSection}
+                        onDuplicate={editor.duplicateSection}
                         onReorder={editor.reorderSections}
                         onInsertAt={(pos) => {
                           setInsertAtPosition(pos);

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -19,7 +19,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useState } from "react";
 import type { Section } from "@/types/artifact";
 import { SECTION_TYPE_LABELS } from "@/types/artifact";
-import { GripVertical, Plus, Trash2 } from "lucide-react";
+import { Copy, GripVertical, Plus, Trash2 } from "lucide-react";
 
 function getItemCount(section: Section): string | null {
   switch (section.type) {
@@ -64,6 +64,7 @@ interface SortableSectionListProps {
   selectedSectionId: string | null;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
+  onDuplicate: (id: string) => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
   onInsertAt?: (position: number) => void;
 }
@@ -73,11 +74,13 @@ function SortableItem({
   isSelected,
   onSelect,
   onDelete,
+  onDuplicate,
 }: {
   section: Section;
   isSelected: boolean;
   onSelect: () => void;
   onDelete: () => void;
+  onDuplicate: () => void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const { attributes, listeners, setNodeRef, transform, transition } =
@@ -116,7 +119,20 @@ function SortableItem({
           })()}
         </p>
       </div>
+      {!confirmDelete && (
+        <button
+          aria-label="Duplicate section"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDuplicate();
+          }}
+          className="opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-accent transition-opacity"
+        >
+          <Copy className="w-3.5 h-3.5" />
+        </button>
+      )}
       <button
+        aria-label={confirmDelete ? "Confirm delete" : "Delete section"}
         onClick={(e) => {
           e.stopPropagation();
           if (confirmDelete) {
@@ -145,6 +161,7 @@ export function SortableSectionList({
   selectedSectionId,
   onSelect,
   onDelete,
+  onDuplicate,
   onReorder,
   onInsertAt,
 }: SortableSectionListProps) {
@@ -183,6 +200,7 @@ export function SortableSectionList({
                 isSelected={section.id === selectedSectionId}
                 onSelect={() => onSelect(section.id)}
                 onDelete={() => onDelete(section.id)}
+                onDuplicate={() => onDuplicate(section.id)}
               />
               {onInsertAt && <InsertDivider onClick={() => onInsertAt(index + 1)} />}
             </div>

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -41,6 +41,7 @@ interface SplitViewLayoutProps {
   onReplaceSection: (sectionId: string, updated: Section) => void;
   // Sidebar overlay props
   onDeleteSection: (id: string) => void;
+  onDuplicateSection: (id: string) => void;
   onReorderSections: (from: number, to: number) => void;
   onAddSection: (section: Section, position?: number) => void;
   onAddSections: (sections: Section[], position?: number) => void;
@@ -68,6 +69,7 @@ export function SplitViewLayout({
   onFieldChange,
   onReplaceSection,
   onDeleteSection,
+  onDuplicateSection,
   onReorderSections,
   onAddSection,
   onAddSections,
@@ -292,6 +294,7 @@ export function SplitViewLayout({
                           handleCloseSidebarOverlay();
                         }}
                         onDelete={onDeleteSection}
+                        onDuplicate={onDuplicateSection}
                         onReorder={onReorderSections}
                         onInsertAt={(pos) => {
                           setInsertAtPosition(pos);

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -102,6 +102,27 @@ export function useEditor(initialArtifact: Artifact) {
     [markUnsaved]
   );
 
+  // Duplicate a section by ID — deep copy with new ID inserted immediately after original
+  const duplicateSection = useCallback(
+    (sectionId: string) => {
+      setArtifact((prev) => {
+        const idx = prev.sections.findIndex((s) => s.id === sectionId);
+        if (idx === -1) return prev;
+        const original = prev.sections[idx];
+        const copy: Section = {
+          ...JSON.parse(JSON.stringify(original)),
+          id: crypto.randomUUID(),
+          title: `${original.title} (Copy)`,
+        };
+        const sections = [...prev.sections];
+        sections.splice(idx + 1, 0, copy);
+        return { ...prev, sections };
+      });
+      markUnsaved();
+    },
+    [markUnsaved]
+  );
+
   // Add multiple sections at a specific position (batch insert, single auto-save)
   const addSections = useCallback(
     (sections: Section[], position?: number) => {
@@ -136,6 +157,7 @@ export function useEditor(initialArtifact: Artifact) {
     updateSectionField,
     reorderSections,
     deleteSection,
+    duplicateSection,
     addSection,
     addSections,
     mergeArtifact,


### PR DESCRIPTION
## What changed
Added a Copy icon to each section row in the sidebar. Clicking it creates an exact deep copy of the section with a new ID, inserts it immediately below, and appends "(Copy)" to the title.

## Why
Duplicating a section is a high-frequency need (e.g. two very similar personas, or cloning a metric template). Without it, users must re-enter content manually.

## Behavior
- Copy icon hidden by default, revealed on row hover (same pattern as the existing delete button)
- Duplicate button hidden when delete confirmation is active (avoids crowding)
- Deep copy via `JSON.parse(JSON.stringify(...))` + `crypto.randomUUID()` for new ID
- Title gets "(Copy)" suffix so the duplicate is immediately distinguishable
- Wired through `SplitViewLayout` as a new `onDuplicateSection` prop (same pattern as `onDeleteSection`)

## Rubric item
QR-09 | Priority 2: Interaction Completeness

## Files modified
- `src/hooks/useEditor.ts` — new `duplicateSection` callback
- `src/components/editor/SortableSectionList.tsx` — new `onDuplicate` prop + Copy button
- `src/components/editor/SplitViewLayout.tsx` — new `onDuplicateSection` prop
- `src/components/editor/EditorLayout.tsx` — wired to `editor.duplicateSection`

## Tier
**Tier 2** — new visible interaction. Held for Jon's review.