### PR TITLE
Add branded 404 page for missing artifact slugs (QR-18)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -132,12 +132,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Hard-refresh an artifact page — see skeleton animation, then smooth transition to content (no blank flash)
 - **Status:** OPEN
 
-### QR-18: Graceful 404 for missing artifacts
-- **Tier:** 2
-- **What:** Instead of Next.js default notFound(), show a branded 404 page with "This document doesn't exist" message and a CTA to visit sharestrata.com
-- **Files:** `src/app/[slug]/page.tsx`, create `src/app/[slug]/not-found.tsx`
-- **Test:** Visit `/nonexistent-slug` → see branded error page, not blank or generic 404
-- **Status:** OPEN
+### ~~QR-18: Graceful 404 for missing artifacts~~ DONE
+- **Status:** DONE — PR opened 2026-04-04. Created `src/app/[slug]/not-found.tsx` — branded dark-theme 404 with "This document doesn't exist" heading and "Create your own" CTA to sharestrata.com. `page.tsx` unchanged.
 
 ### QR-19: Generate og:image for social sharing
 - **Tier:** 2

--- a/src/app/[slug]/not-found.tsx
+++ b/src/app/[slug]/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+export default function ArtifactNotFound() {
+  return (
+    <div className="min-h-screen bg-[#0a0b10] flex items-center justify-center px-6">
+      <div className="text-center max-w-sm">
+        <p className="text-[10px] font-medium text-[#6366f1]/60 uppercase tracking-widest mb-6">
+          Strata
+        </p>
+        <h1 className="text-2xl font-bold text-[#e8eaf0] mb-3">
+          This document doesn&apos;t exist
+        </h1>
+        <p className="text-sm text-[#8b92a8] mb-8">
+          The link may be expired, mistyped, or the document was removed by its author.
+        </p>
+        <Link
+          href="https://sharestrata.com"
+          className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium bg-[#6366f1] text-white hover:bg-[#6366f1]/80 transition-colors"
+        >
+          Create your own
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
Created `src/app/[slug]/not-found.tsx` — a branded dark-theme 404 page shown when an artifact slug doesn't exist.

## Why
Next.js's default `notFound()` renders a generic, unstyled 404. For a product where the artifact IS the shareable artifact, a dead link landing on a raw Next.js error page looks unprofessional.

## Behavior
- Automatically shown by Next.js App Router whenever `notFound()` is called in the `[slug]` route
- Shows: "Strata" wordmark, "This document doesn't exist" heading, one-line explanation, "Create your own" CTA
- CTA links to sharestrata.com
- Dark theme matches the artifact viewer
- No changes to `page.tsx` — notFound() calls unchanged

## Rubric item
QR-18 | Priority 5: Viewer Quality

## Files modified
- `src/app/[slug]/not-found.tsx` (new file)

## Tier
**Tier 2** — user-visible page. Held for Jon's review.