### PR TITLE
Fix OG image to use public artifact fetch only (QR-19)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -139,12 +139,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **Test:** Visit `/nonexistent-slug` → see branded error page, not blank or generic 404
 - **Status:** OPEN
 
-### QR-19: Generate og:image for social sharing
-- **Tier:** 2
-- **What:** Add dynamic Open Graph meta tags (title, description, image) so shared artifact links show a rich preview in Slack, email, Twitter. Use Next.js `generateMetadata` with the artifact title/subtitle.
-- **Files:** `src/app/[slug]/page.tsx` (metadata), optionally `src/app/[slug]/opengraph-image.tsx`
-- **Test:** Share an artifact link in Slack → see title, description, and preview image
-- **Status:** OPEN
+### ~~QR-19: Generate og:image for social sharing~~ DONE
+- **Status:** DONE — PR opened 2026-04-04. `opengraph-image.tsx` already existed and is well-implemented. Fixed one bug: it was using `getArtifactForEdit` (no `is_published` filter) instead of `getArtifactBySlug` (public-only). OG metadata (`title`, `description`, `openGraph`, `twitter`) is set in `generateMetadata` in `page.tsx`.
 
 ### QR-20: Mobile-friendly beats navigation
 - **Tier:** 2

--- a/src/app/[slug]/opengraph-image.tsx
+++ b/src/app/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { getArtifactBySlug, getArtifactForEdit } from "@/lib/artifacts/actions";
+import { getArtifactBySlug } from "@/lib/artifacts/actions";
 
 export const runtime = "edge";
 export const alt = "Strata — Interactive Strategy Artifact";
@@ -20,7 +20,7 @@ export default async function OGImage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const artifact = await getArtifactForEdit(slug);
+  const artifact = await getArtifactBySlug(slug);
 
   if (!artifact) {
     // Fallback: generic Strata card


### PR DESCRIPTION
## What changed
Fixed `src/app/[slug]/opengraph-image.tsx` to use `getArtifactBySlug()` instead of `getArtifactForEdit()`.

## Why
The existing OG image template is well-implemented (title, subtitle, palette bars, section count, author — all rendering at 1200×630). But it was using `getArtifactForEdit()` which:
1. Uses the service role key (bypasses RLS)
2. Has no `is_published` filter — meaning **unpublished drafts show OG previews**

Swapping to `getArtifactBySlug()` ensures only published artifacts generate social previews, matching the same access control as the public viewer.

## Rubric item
QR-19 | Priority 5: Viewer Quality

## Files modified
- `src/app/[slug]/opengraph-image.tsx` (1-line change)

## Tier
**Tier 2** — security-adjacent behavior change. Held for Jon's review.