### PR TITLE
Normalize disabled:opacity-50 to opacity-30 + cursor-not-allowed in app pages

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -461,7 +461,7 @@ export default function CreatePage() {
                 <button
                   onClick={handlePublish}
                   disabled={isPublishing}
-                  className="flex items-center gap-2 rounded-xl bg-accent px-6 py-2.5 text-sm font-semibold text-white hover:bg-accent-hover transition-colors disabled:opacity-50"
+                  className="flex items-center gap-2 rounded-xl bg-accent px-6 py-2.5 text-sm font-semibold text-white hover:bg-accent-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                 >
                   {isPublishing ? (
                     <>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -245,7 +245,7 @@ function ArtifactSection({
                     <button
                       onClick={() => onArchive(artifact.slug)}
                       disabled={actionLoading === artifact.slug}
-                      className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted hover:text-foreground hover:bg-card-hover transition-colors disabled:opacity-50"
+                      className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted hover:text-foreground hover:bg-card-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                     >
                       {actionLoading === artifact.slug ? (
                         <Loader2 className="h-3 w-3 animate-spin" />
@@ -262,7 +262,7 @@ function ArtifactSection({
                 <button
                   onClick={() => onUnarchive(artifact.slug)}
                   disabled={actionLoading === artifact.slug}
-                  className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-accent hover:bg-card-hover transition-colors disabled:opacity-50"
+                  className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-accent hover:bg-card-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                 >
                   {actionLoading === artifact.slug ? (
                     <Loader2 className="h-3 w-3 animate-spin" />


### PR DESCRIPTION
## What changed

Normalized `disabled:opacity-50` → `disabled:opacity-30 disabled:cursor-not-allowed` in `dashboard/page.tsx` and `create/page.tsx`.

## Why

The design system specifies `disabled:opacity-30 disabled:cursor-not-allowed` as the standard disabled state for all buttons. These 3 instances in app pages used `opacity-50` with no `cursor-not-allowed` — inconsistent with the editor components fixed in PR #21.

## Which rubric item

Discovery — not on the rubric. Off-rubric fix extending PR #21 scope to app pages.

## Files modified

- `src/app/dashboard/page.tsx` — 2 instances (Archive + Unarchive buttons)
- `src/app/create/page.tsx` — 1 instance (Publish button)

## Tier

**Tier 0** — Token-only change. No behavior change possible. `disabled:opacity-50` → `disabled:opacity-30 disabled:cursor-not-allowed`.