### PR TITLE
Add missing browser/node globals to ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,22 @@ export default [
         setInterval: "readonly",
         clearInterval: "readonly",
         performance: "readonly",
+        // Browser Web APIs
+        File: "readonly",
+        FileReader: "readonly",
+        FormData: "readonly",
+        URLSearchParams: "readonly",
+        AbortController: "readonly",
+        AbortSignal: "readonly",
+        navigator: "readonly",
+        // DOM types
+        DOMException: "readonly",
+        MouseEvent: "readonly",
+        Node: "readonly",
+        localStorage: "readonly",
+        // Node.js globals
+        Buffer: "readonly",
+        crypto: "readonly",
       },
     },
     rules: {

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -226,7 +226,6 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
     }
     chat.clearHistory();
     setPendingSuggestion(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor.selectedSectionId]);
 
   const paletteStyle: React.CSSProperties = editor.artifact.branding?.palette

--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -103,7 +103,6 @@ export function LogoUpload({
     return (
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-white/20 bg-white/5 p-1">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={logoUrl}
             alt="Logo preview"

--- a/src/components/viewer/SidebarNav.tsx
+++ b/src/components/viewer/SidebarNav.tsx
@@ -94,7 +94,6 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
         <div className="border-b border-border px-6 py-6">
           {logoUrl && (
             <div className="mb-3">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={logoUrl} alt="" className="h-8 w-auto object-contain" />
             </div>
           )}


### PR DESCRIPTION
## What changed
Added 13 missing Web API and Node.js globals to `eslint.config.mjs`: `File`, `FileReader`, `FormData`, `URLSearchParams`, `AbortController`, `AbortSignal`, `navigator`, `DOMException`, `MouseEvent`, `Node`, `localStorage`, `Buffer`, `crypto`.

Also removed 3 stale `eslint-disable` comments referencing plugins that are not installed (`react-hooks/exhaustive-deps`, `@next/next/no-img-element`). Since the plugins were never loaded, the rules were never enforced — the comments were noise.

## Why
`npm run lint` reported 50 `no-undef` errors for standard browser and Node.js globals. These are false positives — the code is correct, the config was incomplete. Reduces lint output from **150 problems (50 errors, 100 warnings)** to **100 problems (0 errors, 100 warnings)**.

## Rubric item
Discovered (off-rubric) — no rubric item number. Logged to `docs/agents/coordination-log.md`.

## Files modified
- `eslint.config.mjs`
- `src/components/editor/EditorLayout.tsx` (removed stale disable comment)
- `src/components/editor/LogoUpload.tsx` (removed stale disable comment)
- `src/components/viewer/SidebarNav.tsx` (removed stale disable comment)

## Tier
**Tier 0** — config and comment-only change. No behavior change possible.

https://claude.ai/code/session_01WqQhAENzXhZcv5easC5Fh1