### PR TITLE
Fix unused variable warnings in hooks

### DIFF
--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import type { Section, SectionType } from "@/types/artifact";
+import type { SectionType } from "@/types/artifact";
 
 export interface ChatSuggestion {
   type: "section" | "document";

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -8,7 +8,7 @@ import type { SaveStatus } from "./useEditor";
 export function useAutoSave(
   artifact: Artifact,
   saveStatus: SaveStatus,
-  setSaveStatus: (status: SaveStatus) => void,
+  setSaveStatus: (_status: SaveStatus) => void,
   debounceMs: number = 2000
 ) {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -29,7 +29,7 @@ export function useEditor(initialArtifact: Artifact) {
 
   // Replace an entire section by ID
   const updateSection = useCallback(
-    (sectionId: string, updater: (s: Section) => Section) => {
+    (sectionId: string, updater: (_s: Section) => Section) => {
       setArtifact((prev) => ({
         ...prev,
         sections: prev.sections.map((s) =>


### PR DESCRIPTION
## What changed
- `useAiChat.ts`: removed unused `Section` type import (only `SectionType` is used)
- `useAutoSave.ts`: renamed `status` → `_status` in the `setSaveStatus` callback type signature (matches `argsIgnorePattern: ^_` ESLint rule)
- `useEditor.ts`: renamed `s` → `_s` in the `updater` callback type signature for the same reason

## Why
Three `no-unused-vars` warnings in hooks. No behavior change — these are import removal and type-level parameter renames only.

## Rubric item
Discovered (off-rubric). Logged to `docs/agents/coordination-log.md`.

## Files modified
- `src/hooks/useAiChat.ts`
- `src/hooks/useAutoSave.ts`
- `src/hooks/useEditor.ts`

## Tier
**Tier 0** — import removal and parameter rename in type signatures only. No behavior change possible.

https://claude.ai/code/session_01WqQhAENzXhZcv5easC5Fh1