### PR TITLE
Rename unused callback parameter names to match _-prefix convention

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -186,8 +186,8 @@ function ArtifactSection({
   count: number;
   artifacts: Artifact[];
   actionLoading: string | null;
-  onArchive?: (slug: string) => void;
-  onUnarchive?: (slug: string) => void;
+  onArchive?: (_slug: string) => void;
+  onUnarchive?: (_slug: string) => void;
   isArchived?: boolean;
 }) {
   return (

--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -214,7 +214,7 @@ function TimelineTrack({
   phases: JourneyPhase[];
   activeIndex: number;
   visited: Set<number>;
-  onSelect: (index: number) => void;
+  onSelect: (_index: number) => void;
 }) {
   const trackRef = useRef<HTMLDivElement>(null);
   const hasMounted = useRef(false);


### PR DESCRIPTION
## What changed
Two type-signature-only parameter renames to silence `no-unused-vars` warnings:

1. **`dashboard/page.tsx`** — `slug` → `_slug` in `onArchive` and `onUnarchive` prop types
2. **`GuidedJourney.tsx`** — `index` → `_index` in the `onSelect` prop type of the ProgressBar subcomponent

## Why
ESLint flags named parameters in callback type signatures when the name appears only in the type, not in a function body. Renaming to `_prefix` matches the `argsIgnorePattern: ^_` rule in `eslint.config.mjs`. Zero behavior change in both cases.

## Rubric item
Discovered (off-rubric). Logged to `docs/agents/coordination-log.md`.

## Files modified
- `src/app/dashboard/page.tsx`
- `src/components/viewer/sections/GuidedJourney.tsx`

## Tier
**Tier 0** — type-signature parameter renames only. No behavior change possible.

https://claude.ai/code/session_01WqQhAENzXhZcv5easC5Fh1