### PR TITLE
Fix unused variable warnings in AddSection components and vision API route

### DIFF
--- a/src/app/api/ai/vision-to-section/route.ts
+++ b/src/app/api/ai/vision-to-section/route.ts
@@ -121,9 +121,7 @@ export async function POST(req: NextRequest) {
     if (!section.id || typeof section.id !== "string") {
       section.id = `vision-${Date.now()}`;
     }
-    // Check for ID collision with existing sections
-    const existingSectionIds = (context?.existingSectionTypes ?? []);
-    // Client sends section types, not IDs — but we can't know IDs server-side.
+    // Client sends section types, not IDs — can't check collisions server-side.
     // Add timestamp suffix to guarantee uniqueness.
     section.id = `${section.id}-${Date.now().toString(36)}`;
 

--- a/src/components/editor/AddSection.tsx
+++ b/src/components/editor/AddSection.tsx
@@ -30,8 +30,8 @@ const MODE_TABS: { id: AddSectionMode; label: string; icon: typeof Pencil; disab
 interface AddSectionProps {
   documentTitle: string;
   documentSubtitle?: string;
-  onAdd: (section: Section) => void;
-  onAddMultiple?: (sections: Section[]) => void;
+  onAdd: (_section: Section) => void;
+  onAddMultiple?: (_sections: Section[]) => void;
   onCancel: () => void;
 }
 

--- a/src/components/editor/AddSectionPaste.tsx
+++ b/src/components/editor/AddSectionPaste.tsx
@@ -10,7 +10,7 @@ const MAX_CHARS = 50_000;
 interface AddSectionPasteProps {
   documentTitle: string;
   documentSubtitle?: string;
-  onAddMultiple: (sections: Section[]) => void;
+  onAddMultiple: (_sections: Section[]) => void;
   onCancel: () => void;
 }
 
@@ -89,15 +89,6 @@ export function AddSectionPaste({
       abortRef.current = null;
     }
   }, [content, isGenerating, documentTitle, documentSubtitle]);
-
-  const handleCancel = useCallback(() => {
-    if (abortRef.current) {
-      abortRef.current.abort();
-      abortRef.current = null;
-    }
-    setIsGenerating(false);
-    onCancel();
-  }, [onCancel]);
 
   // Multi-section review mode
   if (generatedSections) {

--- a/src/components/editor/AddSectionUpload.tsx
+++ b/src/components/editor/AddSectionUpload.tsx
@@ -14,7 +14,7 @@ type UploadState = "idle" | "processing" | "review";
 interface AddSectionUploadProps {
   documentTitle: string;
   documentSubtitle?: string;
-  onAddMultiple: (sections: Section[]) => void;
+  onAddMultiple: (_sections: Section[]) => void;
   onCancel: () => void;
 }
 


### PR DESCRIPTION
## What changed

### Prop type parameter renames (3 files)
- `AddSection.tsx`: `section` → `_section`, `sections` → `_sections` in `onAdd`/`onAddMultiple` prop types
- `AddSectionPaste.tsx`: `sections` → `_sections` in `onAddMultiple` prop type
- `AddSectionUpload.tsx`: `sections` → `_sections` in `onAddMultiple` prop type

ESLint flags named callback parameters in TypeScript interface types as `no-unused-vars`. Renaming to `_prefix` matches the `argsIgnorePattern: ^_` rule.

### Dead code removal (2 locations)
- `AddSectionPaste.tsx`: removed `handleCancel` const — it was defined with `useCallback` but never called in JSX (the Cancel button uses an inline `onClick` handler instead)
- `vision-to-section/route.ts`: removed unused `existingSectionIds` assignment — a comment already explained it could never be used server-side; replaced with a cleaner single comment

## Why
Reduces `no-unused-vars` warnings. No behavior change in either case — `handleCancel` was never invoked, and `existingSectionIds` was never read.

## Rubric item
Discovered (off-rubric). Logged to `docs/agents/coordination-log.md`.

## Files modified
- `src/components/editor/AddSection.tsx`
- `src/components/editor/AddSectionPaste.tsx`
- `src/components/editor/AddSectionUpload.tsx`
- `src/app/api/ai/vision-to-section/route.ts`

## Tier
**Tier 0** — dead code removal and type-signature parameter renames only. No behavior change possible.

https://claude.ai/code/session_01WqQhAENzXhZcv5easC5Fh1