### PR TITLE
Rename path/value/field params to _-prefix in Editable component prop types

### DIFF
--- a/src/components/editor/DocumentSettings.tsx
+++ b/src/components/editor/DocumentSettings.tsx
@@ -9,7 +9,7 @@ const DEFAULT_SECONDARY = "#f59e0b";
 
 interface DocumentSettingsProps {
   artifact: Artifact;
-  onUpdate: <K extends keyof Artifact>(field: K, value: Artifact[K]) => void;
+  onUpdate: <K extends keyof Artifact>(_field: K, _value: Artifact[K]) => void;
 }
 
 export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) {

--- a/src/components/editor/EditableDataViz.tsx
+++ b/src/components/editor/EditableDataViz.tsx
@@ -15,7 +15,7 @@ const CHART_TYPES = [
 
 interface EditableDataVizProps {
   section: DataVizSection;
-  onFieldChange: (path: string, value: unknown) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
 }
 
 export function EditableDataViz({

--- a/src/components/editor/EditableGuidedJourney.tsx
+++ b/src/components/editor/EditableGuidedJourney.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 
 interface EditableGuidedJourneyProps {
   section: GuidedJourneySection;
-  onFieldChange: (path: string, value: unknown) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
 }
 
 export function EditableGuidedJourney({
@@ -99,7 +99,7 @@ function PhasesEditor({
   onFieldChange,
 }: {
   section: GuidedJourneySection;
-  onFieldChange: (path: string, value: unknown) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
 }) {
   const phases = section.content.phases;
 
@@ -174,7 +174,7 @@ function EventsEditor({
   onFieldChange,
 }: {
   section: GuidedJourneySection;
-  onFieldChange: (path: string, value: unknown) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
 }) {
   const events = section.content.events;
   const phases = section.content.phases;

--- a/src/components/editor/EditableHubMockup.tsx
+++ b/src/components/editor/EditableHubMockup.tsx
@@ -6,7 +6,7 @@ import { ItemManager } from "./ItemManager";
 
 interface EditableHubMockupProps {
   section: HubMockupSection;
-  onFieldChange: (path: string, value: unknown) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
 }
 
 export function EditableHubMockup({
@@ -209,7 +209,7 @@ function LayersEditor({
   onFieldChange,
 }: {
   layers: HubMockupSection["content"]["layers"];
-  onFieldChange: (path: string, value: unknown) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
 }) {
   if (!layers) return null;
 
@@ -329,7 +329,7 @@ function NodeEditor({
 }: {
   prefix: string;
   node: { id: string; label: string; description?: string; color?: string };
-  onFieldChange: (path: string, value: unknown) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
 }) {
   return (
     <div className="flex items-start gap-3 bg-white/5 rounded-lg p-3 border border-white/10">


### PR DESCRIPTION
## What changed

All `Editable*` components share an `onFieldChange: (path: string, value: unknown) => void` prop type. `DocumentSettings` has a similar `onUpdate: <K extends keyof Artifact>(field: K, value: Artifact[K]) => void` type. ESLint flags the named parameters as `no-unused-vars` since they appear only in the type signature, not in an actual function body.

Renamed in all 4 files:
- `path` → `_path`
- `value` → `_value`
- `field` → `_field`

### Files affected (8 occurrences total)
- `EditableDataViz.tsx` — 1 interface
- `EditableGuidedJourney.tsx` — 3 interfaces (subcomponents each have their own)
- `EditableHubMockup.tsx` — 3 interfaces
- `DocumentSettings.tsx` — 1 interface

## Why
Matches the `argsIgnorePattern: ^_` ESLint rule. Zero behavior change — these are type-level parameter name renames only.

## Rubric item
Discovered (off-rubric). Logged to `docs/agents/coordination-log.md`.

## Tier
**Tier 0** — type-signature parameter renames only. No behavior change possible.

https://claude.ai/code/session_01WqQhAENzXhZcv5easC5Fh1