### PR TITLE
Rename unused callback params to _-prefix across 8 remaining editor components

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -5,7 +5,7 @@ import { FormattedText } from "@/components/viewer/FormattedText";
 
 interface InlineEditorProps {
   value: string;
-  onChange: (value: string) => void;
+  onChange: (_value: string) => void;
   multiline?: boolean;
   className?: string;
   placeholder?: string;

--- a/src/components/editor/ItemManager.tsx
+++ b/src/components/editor/ItemManager.tsx
@@ -20,11 +20,11 @@ import { GripVertical, Trash2, Plus } from "lucide-react";
 
 interface ItemManagerProps<T> {
   items: T[];
-  getItemId: (item: T, index: number) => string;
+  getItemId: (_item: T, _index: number) => string;
   onAdd: () => void;
-  onRemove: (index: number) => void;
-  onReorder: (fromIndex: number, toIndex: number) => void;
-  renderItem: (item: T, index: number) => React.ReactNode;
+  onRemove: (_index: number) => void;
+  onReorder: (_fromIndex: number, _toIndex: number) => void;
+  renderItem: (_item: T, _index: number) => React.ReactNode;
   addLabel: string;
   minItems?: number;
   maxItems?: number;

--- a/src/components/editor/MultiSectionReview.tsx
+++ b/src/components/editor/MultiSectionReview.tsx
@@ -18,7 +18,7 @@ function getSectionPreview(section: Section): string {
 
 interface MultiSectionReviewProps {
   sections: Section[];
-  onConfirm: (selected: Section[]) => void;
+  onConfirm: (_selected: Section[]) => void;
   onCancel: () => void;
   onRegenerate: () => void;
 }

--- a/src/components/editor/SectionEditorPanel.tsx
+++ b/src/components/editor/SectionEditorPanel.tsx
@@ -10,9 +10,9 @@ import { Sparkles } from "lucide-react";
 interface SectionEditorPanelProps {
   section: Section;
   sectionIndex: number;
-  onFieldChange: (sectionId: string, path: string, value: unknown) => void;
-  onReplaceSection: (sectionId: string, updated: Section) => void;
-  onPendingPreview?: (section: Section | null) => void;
+  onFieldChange: (_sectionId: string, _path: string, _value: unknown) => void;
+  onReplaceSection: (_sectionId: string, _updated: Section) => void;
+  onPendingPreview?: (_section: Section | null) => void;
 }
 
 export function SectionEditorPanel({

--- a/src/components/editor/SectionPreviewPanel.tsx
+++ b/src/components/editor/SectionPreviewPanel.tsx
@@ -10,7 +10,7 @@ interface SectionPreviewPanelProps {
   artifact: Artifact;
   isZoomedOut: boolean;
   onToggleZoom: () => void;
-  onSelectSection: (id: string) => void;
+  onSelectSection: (_id: string) => void;
 }
 
 // Memoize to avoid re-renders during rapid typing in the editor panel.

--- a/src/components/editor/SidebarRail.tsx
+++ b/src/components/editor/SidebarRail.tsx
@@ -29,7 +29,7 @@ const SECTION_TYPE_ICONS: Record<SectionType, LucideIcon> = {
 interface SidebarRailProps {
   sections: Section[];
   selectedSectionId: string | null;
-  onSelectSection: (id: string) => void;
+  onSelectSection: (_id: string) => void;
   onExpandSidebar: () => void;
 }
 

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -62,11 +62,11 @@ function InsertDivider({ onClick }: { onClick: () => void }) {
 interface SortableSectionListProps {
   sections: Section[];
   selectedSectionId: string | null;
-  onSelect: (id: string) => void;
-  onDelete: (id: string) => void;
-  onDuplicate: (id: string) => void;
-  onReorder: (fromIndex: number, toIndex: number) => void;
-  onInsertAt?: (position: number) => void;
+  onSelect: (_id: string) => void;
+  onDelete: (_id: string) => void;
+  onDuplicate: (_id: string) => void;
+  onReorder: (_fromIndex: number, _toIndex: number) => void;
+  onInsertAt?: (_position: number) => void;
 }
 
 function SortableItem({

--- a/src/components/viewer/ArtifactViewer.tsx
+++ b/src/components/viewer/ArtifactViewer.tsx
@@ -83,8 +83,6 @@ export function ArtifactViewer({
       }
     };
 
-    // Attach to the scroll container if available, otherwise window
-    const container = scrollContainerRef.current ?? window;
     // scrollIntoView works relative to the viewport, so window keydown is fine
     window.addEventListener("keydown", handleKeyDown);
     return () => {


### PR DESCRIPTION
## What changed

All affected callback type signatures used concrete parameter names that ESLint flagged as `no-unused-vars`. Renamed to `_`-prefix to match the `argsIgnorePattern: ^_` rule. Also removed a dead `container` variable in `ArtifactViewer.tsx`.

### Files and changes
| File | What changed |
|------|--------------|
| `InlineEditor.tsx` | `onChange(value)` → `onChange(_value)` |
| `ItemManager.tsx` | `getItemId`, `onRemove`, `onReorder`, `renderItem` param renames |
| `MultiSectionReview.tsx` | `onConfirm(selected)` → `onConfirm(_selected)` |
| `SectionEditorPanel.tsx` | `onFieldChange`, `onReplaceSection`, `onPendingPreview` param renames |
| `SectionPreviewPanel.tsx` | `onSelectSection(id)` → `onSelectSection(_id)` |
| `SidebarRail.tsx` | `onSelectSection(id)` → `onSelectSection(_id)` |
| `SortableSectionList.tsx` | `onSelect`, `onDelete`, `onDuplicate`, `onReorder`, `onInsertAt` param renames |
| `ArtifactViewer.tsx` | Remove dead `container = scrollContainerRef.current ?? window` (variable assigned, never read — `window` listener used directly) |

## Why
Reduces `no-unused-vars` warnings to near-zero across the codebase. All are type-signature renames with zero behavior change.

## Rubric item
Discovered (off-rubric). Logged to `docs/agents/coordination-log.md`.

## Tier
**Tier 0** — type-signature renames and one dead-assignment removal. No behavior change possible.

https://claude.ai/code/session_01WqQhAENzXhZcv5easC5Fh1