### PR TITLE
Remove debug console.log from waitlist catch block

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -47,7 +47,6 @@ export default function DiscoverPage() {
       if (!res.ok) throw new Error("Failed to submit");
     } catch {
       // Silently succeed even if API isn't ready yet — don't block the UX
-      console.log("Waitlist submission:", { email, role, useCase });
     }
 
     setSubmitted(true);


### PR DESCRIPTION
## What changed
Removed a `console.log` debug statement from the waitlist form catch block in `discover/page.tsx`.

## Why
The catch block is explicitly intended to be silent (comment: "Silently succeed even if API isn't ready yet — don't block the UX"). The log was leaking submission data (`email`, `role`, `useCase`) to the browser console in production. Removing it makes the silence actually silent.

## Rubric item
Discovered (off-rubric). Logged to `docs/agents/coordination-log.md`.

## Files modified
- `src/app/discover/page.tsx`

## Tier
**Tier 0** — single line deletion in a catch block. No behavior change.

https://claude.ai/code/session_01WqQhAENzXhZcv5easC5Fh1