### PR TITLE
Replace raw hex colors with CSS variable tokens in not-found.tsx

### DIFF
--- a/src/app/[slug]/not-found.tsx
+++ b/src/app/[slug]/not-found.tsx
@@ -2,20 +2,20 @@ import Link from "next/link";
 
 export default function ArtifactNotFound() {
   return (
-    <div className="min-h-screen bg-[#0a0b10] flex items-center justify-center px-6">
+    <div className="min-h-screen bg-background flex items-center justify-center px-6">
       <div className="text-center max-w-sm">
-        <p className="text-[10px] font-medium text-[#6366f1]/60 uppercase tracking-widest mb-6">
+        <p className="text-[10px] font-medium text-accent/60 uppercase tracking-widest mb-6">
           Strata
         </p>
-        <h1 className="text-2xl font-bold text-[#e8eaf0] mb-3">
+        <h1 className="text-2xl font-bold text-foreground mb-3">
           This document doesn&apos;t exist
         </h1>
-        <p className="text-sm text-[#8b92a8] mb-8">
+        <p className="text-sm text-muted mb-8">
           The link may be expired, mistyped, or the document was removed by its author.
         </p>
         <Link
           href="https://sharestrata.com"
-          className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium bg-[#6366f1] text-white hover:bg-[#6366f1]/80 transition-colors"
+          className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium bg-accent text-white hover:bg-accent/80 transition-colors"
         >
           Create your own
         </Link>


### PR DESCRIPTION
## What changed
Replaced 5 hard-coded hex color literals with design-system CSS variable utilities in `src/app/[slug]/not-found.tsx`:
- `bg-[#0a0b10]` → `bg-background`
- `text-[#6366f1]/60` → `text-accent/60`
- `text-[#e8eaf0]` → `text-foreground`
- `text-[#8b92a8]` → `text-muted`
- `bg-[#6366f1]` / `hover:bg-[#6366f1]/80` → `bg-accent` / `hover:bg-accent/80`

## Why
Design system rule: never use raw hex in components. All colors must come from CSS variables in `globals.css`. Raw hex bypasses theme switching and makes future palette changes require grep-and-replace instead of a single variable update.

## Rubric item
Off-rubric discovery. Design-system reference: Colors section — "All colors come from CSS variables in `globals.css`. Never use raw hex in components."

## Files modified
- `src/app/[slug]/not-found.tsx`

## Tier
**Tier 0** — CSS variable unification. No behavior change. Computed colors are identical.