### PR TITLE
Replace raw hex bg-[#12141d]/90 with bg-surface/90 in mobile nav pill

### DIFF
--- a/src/components/viewer/ProgressBarNav.tsx
+++ b/src/components/viewer/ProgressBarNav.tsx
@@ -122,7 +122,7 @@ export function ProgressBarNav({
 
       {/* Mobile floating pill — shown only on small screens */}
       <div
-        className="sm:hidden fixed bottom-5 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-3 py-2 rounded-full border border-white/10 bg-[#12141d]/90 backdrop-blur-sm shadow-lg"
+        className="sm:hidden fixed bottom-5 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-3 py-2 rounded-full border border-white/10 bg-surface/90 backdrop-blur-sm shadow-lg"
         role="navigation"
         aria-label="Section navigation"
       >


### PR DESCRIPTION
## What changed
Mobile floating section-nav pill in `ProgressBarNav.tsx` was using `bg-[#12141d]/90` — a hard-coded hex that bypasses theme variables. Replaced with `bg-surface/90`, the correct design-system token for elevated surfaces.

## Why
Design system rule: all colors must come from CSS variables, never raw hex. `--color-surface: #12141d` is the defined token for this value.

## Rubric item
Off-rubric discovery. Design-system reference: Colors section — "Never use raw hex in components."

## Files modified
- `src/components/viewer/ProgressBarNav.tsx` (1 line)

## Tier
**Tier 0** — CSS variable unification. No behavior change. Identical computed color.