### PR TITLE
Normalize font-semibold to design-system weights in editor components

### DIFF
--- a/src/components/editor/EditableHubMockup.tsx
+++ b/src/components/editor/EditableHubMockup.tsx
@@ -257,7 +257,7 @@ function LayersEditor({
                 onChange={(v) =>
                   onFieldChange(`content.layers.${layerIndex}.label`, v)
                 }
-                className="text-xs font-semibold uppercase tracking-wider text-accent"
+                className="text-xs font-medium uppercase tracking-wider text-accent"
               />
             </div>
           </div>

--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -396,7 +396,7 @@ function EditableCardGrid({
               ))}
             </div>
 
-            <h3 className="font-semibold">
+            <h3 className="font-bold">
               <InlineEditor
                 value={card.title}
                 onChange={(v) => onFieldChange(`content.cards.${i}.title`, v)}
@@ -638,7 +638,7 @@ function EditableTimeline({
               />
             </div>
             <div className="flex-1 bg-white/5 rounded-lg p-4 border border-white/10">
-              <h4 className="font-semibold mb-1">
+              <h4 className="font-bold mb-1">
                 <InlineEditor
                   value={step.title}
                   onChange={(v) => onFieldChange(`content.steps.${i}.title`, v)}
@@ -669,7 +669,7 @@ function EditableTimeline({
 
       {/* Pivot */}
       {section.content.pivot && (
-        <p className="text-lg font-semibold mt-4">
+        <p className="text-lg font-bold mt-4">
           <InlineEditor
             value={section.content.pivot}
             onChange={(v) => onFieldChange("content.pivot", v)}
@@ -747,7 +747,7 @@ function EditableTierTable({
             col.is_highlighted ? "border-accent/50" : "border-white/10"
           }`}
         >
-          <h4 className="font-semibold mb-1">
+          <h4 className="font-bold mb-1">
             <InlineEditor
               value={col.name}
               onChange={(v) => onFieldChange(`content.columns.${i}.name`, v)}

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -455,7 +455,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
               >
                 <ArrowLeft className="w-4 h-4" />
               </Link>
-              <div className="flex-1 min-w-0 text-sm font-semibold">
+              <div className="flex-1 min-w-0 text-sm font-bold">
                 <InlineEditor
                   value={editor.artifact.title}
                   onChange={(v) => editor.updateArtifactField("title", v)}

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -246,7 +246,7 @@ export function SplitViewLayout({
                   >
                     <ArrowLeft className="w-4 h-4" />
                   </Link>
-                  <div className="flex-1 min-w-0 text-sm font-semibold">
+                  <div className="flex-1 min-w-0 text-sm font-bold">
                     <InlineEditor
                       value={artifact.title}
                       onChange={(v) => onUpdateArtifactField("title", v)}


### PR DESCRIPTION
## What changed
Replaced 7 instances of `font-semibold` (not in the design-system type scale) with the correct weights across 4 editor files:

| File | Instance | Old → New |
|------|----------|----------|
| `SplitViewLayout.tsx` | Document title div | `font-semibold` → `font-bold` |
| `EditorLayout.tsx` | Document title div | `font-semibold` → `font-bold` |
| `EditableSectionRenderer.tsx` | `h3` card title | `font-semibold` → `font-bold` |
| `EditableSectionRenderer.tsx` | `h4` step title | `font-semibold` → `font-bold` |
| `EditableSectionRenderer.tsx` | `p.text-lg` pivot | `font-semibold` → `font-bold` |
| `EditableSectionRenderer.tsx` | `h4` column name | `font-semibold` → `font-bold` |
| `EditableHubMockup.tsx` | Uppercase layer label | `font-semibold` → `font-medium` |

## Why
Design system typography scale defines exactly two weights: `font-bold` (section titles, headings) and `font-medium` (buttons, labels). `font-semibold` is not in the scale and creates visual inconsistency between heading weights across the editor.

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Weights section.

## Files modified
- `src/components/editor/SplitViewLayout.tsx`
- `src/components/editor/EditorLayout.tsx`
- `src/components/editor/EditableSectionRenderer.tsx`
- `src/components/editor/EditableHubMockup.tsx`

## Tier
**Tier 0** — Typography token normalization. No behavior change.