### PR TITLE
Remove unused X import in create/page.tsx; rename url param in LogoUpload

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -13,7 +13,6 @@ import {
   RotateCcw,
   Upload,
   FileText,
-  X,
 } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";

--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -6,7 +6,7 @@ import { Upload, X, ImageIcon } from "lucide-react";
 interface LogoUploadProps {
   logoUrl?: string;
   artifactId: string;
-  onUpload: (url: string) => void;
+  onUpload: (_url: string) => void;
   onRemove: () => void;
 }
 


### PR DESCRIPTION
## What changed

1. **`create/page.tsx`** — Removed `X` from the lucide-react import block. It was never rendered anywhere in the file.
2. **`LogoUpload.tsx`** — Renamed `(url: string)` → `(_url: string)` in the `onUpload` prop type. ESLint flags named parameters in TypeScript interface callback signatures as `no-unused-vars`; the `_` prefix matches the `argsIgnorePattern: ^_` rule.

## Why
Clears two ESLint warnings from `npm run lint`. No behavior change in either file.

## Rubric item
Off-rubric discovery. Follows the same pattern as PRs #36–39.

## Files modified
- `src/app/create/page.tsx`
- `src/components/editor/LogoUpload.tsx`

## Tier
**Tier 0** — unused import removal and type-signature rename. Zero behavior change.