### PR TITLE
Remove unused imports in AiChatPanel/useAiChat; rename param in TypeSelectorDropdown

### DIFF
--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import type { Section, SectionType } from "@/types/artifact";
-import type { ChatMessage, ChatSuggestion, ChatScope } from "@/hooks/useAiChat";
+import type { SectionType } from "@/types/artifact";
+import type { ChatMessage, ChatScope } from "@/hooks/useAiChat";
 import { getQuickChips } from "@/hooks/useAiChat";
 import { Sparkles, Send, Loader2, Check, X, RotateCcw } from "lucide-react";
 

--- a/src/components/editor/TypeSelectorDropdown.tsx
+++ b/src/components/editor/TypeSelectorDropdown.tsx
@@ -19,7 +19,7 @@ const ALL_TYPES: SectionType[] = [
 
 interface TypeSelectorDropdownProps {
   section: Section;
-  onTypeChange: (remappedSection: Section) => void;
+  onTypeChange: (_remappedSection: Section) => void;
 }
 
 export function TypeSelectorDropdown({

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import type { Section, SectionType } from "@/types/artifact";
+import type { SectionType } from "@/types/artifact";
 
 export interface ChatSuggestion {
   type: "section" | "document";


### PR DESCRIPTION
## What changed

1. **`AiChatPanel.tsx`** — Removed unused `Section` and `ChatSuggestion` type imports. `SectionType` and `ChatScope` remain (they are used).
2. **`useAiChat.ts`** — Removed unused `Section` type import. `SectionType` remains.
3. **`TypeSelectorDropdown.tsx`** — Renamed `(remappedSection: Section)` → `(_remappedSection: Section)` in the `onTypeChange` prop type signature to match the `argsIgnorePattern: ^_` ESLint rule.

## Why
Clears 3 ESLint `no-unused-vars` warnings. No behavior change.

## Rubric item
Off-rubric discovery. Same pattern as PRs #36–39.

## Files modified
- `src/components/editor/AiChatPanel.tsx`
- `src/hooks/useAiChat.ts`
- `src/components/editor/TypeSelectorDropdown.tsx`

## Tier
**Tier 0** — unused import removal and type-signature rename only.