### PR TITLE
Rename unused callback params to _-prefix in SplitViewLayout prop types

### DIFF
--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -37,9 +37,9 @@ interface SplitViewLayoutProps {
   selectedSection: Section;
   previewSection?: Section; // With AI suggestion overlay, if any
   selectedSectionIndex: number;
-  onSelectSection: (id: string) => void;
-  onFieldChange: (sectionId: string, path: string, value: unknown) => void;
-  onReplaceSection: (sectionId: string, updated: Section) => void;
+  onSelectSection: (_id: string) => void;
+  onFieldChange: (_sectionId: string, _path: string, _value: unknown) => void;
+  onReplaceSection: (_sectionId: string, updated: Section) => void;
   // Sidebar overlay props
   onDeleteSection: (id: string) => void;
   onDuplicateSection: (id: string) => void;


### PR DESCRIPTION
## What changed
Renamed 5 parameter names in the `SplitViewLayoutProps` interface that ESLint flags as `no-unused-vars`:
- `onSelectSection: (id)` → `(_id)`
- `onFieldChange: (sectionId, path, value)` → `(_sectionId, _path, _value)`
- `onReplaceSection: (sectionId, updated)` → `(_sectionId, updated)`

## Why
ESLint `no-unused-vars` flags named parameters in TypeScript interface callback types. Renaming to `_` prefix matches the `argsIgnorePattern: ^_` rule. Zero behavior change.

## Rubric item
Off-rubric discovery. Same pattern as PRs #36–39.

## Files modified
- `src/components/editor/SplitViewLayout.tsx`

## Tier
**Tier 0** — type-signature parameter renames only.