### PR TITLE
Rename unused callback params to _-prefix in EditableSectionRenderer prop types

### DIFF
--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -22,8 +22,8 @@ import { EditableHubMockup } from "./EditableHubMockup";
 interface EditableSectionRendererProps {
   section: Section;
   isSelected?: boolean;
-  onFieldChange: (path: string, value: unknown) => void;
-  onReplaceSection?: (updated: Section) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
+  onReplaceSection?: (_updated: Section) => void;
 }
 
 export function EditableSectionRenderer({
@@ -106,8 +106,8 @@ function SectionImagePreview({
   onReplaceSection,
 }: {
   section: Section;
-  onFieldChange: (path: string, value: unknown) => void;
-  onReplaceSection?: (updated: Section) => void;
+  onFieldChange: (_path: string, _value: unknown) => void;
+  onReplaceSection?: (_updated: Section) => void;
 }) {
   const [isExtracting, setIsExtracting] = useState(false);
   const [extractError, setExtractError] = useState<string | null>(null);


### PR DESCRIPTION
## What changed
Renamed callback parameter names in the `onFieldChange` and `onReplaceSection` type signatures in `EditableSectionRenderer.tsx`. Both the named interface at the top of the file and the inline object type used in the section-image branch had the same issue:
- `(path: string, value: unknown)` → `(_path: string, _value: unknown)`
- `(updated: Section)` → `(_updated: Section)`

## Why
ESLint `no-unused-vars` at lines 25-26 and 109-110. Same pattern as PRs #36–39.

## Rubric item
Off-rubric discovery.

## Files modified
- `src/components/editor/EditableSectionRenderer.tsx`

## Tier
**Tier 0** — type-signature renames only. Zero behavior change.