### PR TITLE
Normalize font-semibold to design-system weights in viewer components

### DIFF
--- a/src/components/viewer/FormattedText.tsx
+++ b/src/components/viewer/FormattedText.tsx
@@ -11,7 +11,7 @@ export function FormattedText({ text, className }: FormattedTextProps) {
     <span className={className}>
       {parts.map((part, i) => {
         if (part.startsWith("**") && part.endsWith("**")) {
-          return <strong key={i} className="font-semibold text-foreground">{part.slice(2, -2)}</strong>;
+          return <strong key={i} className="font-bold text-foreground">{part.slice(2, -2)}</strong>;
         }
         return <span key={i}>{part}</span>;
       })}

--- a/src/components/viewer/SidebarNav.tsx
+++ b/src/components/viewer/SidebarNav.tsx
@@ -98,7 +98,7 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
               <img src={logoUrl} alt="" className="h-8 w-auto object-contain" />
             </div>
           )}
-          <h2 className="text-sm font-semibold tracking-wide text-foreground">
+          <h2 className="text-sm font-bold tracking-wide text-foreground">
             {title}
           </h2>
           {subtitle && (

--- a/src/components/viewer/StrataFooter.tsx
+++ b/src/components/viewer/StrataFooter.tsx
@@ -18,7 +18,7 @@ export function StrataFooter({ planTier = "free", isDemoPage = false }: StrataFo
           </p>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
-              <p className="text-lg font-semibold text-foreground">
+              <p className="text-lg font-bold text-foreground">
                 Like what you see? Build yours in 30 minutes.
               </p>
               <p className="mt-1 text-sm text-muted">
@@ -27,7 +27,7 @@ export function StrataFooter({ planTier = "free", isDemoPage = false }: StrataFo
             </div>
             <a
               href="/create"
-              className="inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 shrink-0"
+              className="inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 shrink-0"
               style={{ backgroundColor: "var(--palette-accent1, var(--color-accent))" }}
             >
               <Layers className="h-4 w-4" />

--- a/src/components/viewer/sections/AnimatedTimeline.tsx
+++ b/src/components/viewer/sections/AnimatedTimeline.tsx
@@ -64,10 +64,10 @@ function VerticalStep({
 
       {/* Content */}
       <div className={cn("pb-10", isLast && "pb-0")}>
-        <span className="text-xs font-semibold uppercase tracking-wider text-accent">
+        <span className="text-xs font-medium uppercase tracking-wider text-accent">
           {step.label}
         </span>
-        <h3 className={cn("mt-1 text-lg font-semibold", styles.text)}>
+        <h3 className={cn("mt-1 text-lg font-bold", styles.text)}>
           {step.title}
         </h3>
         <p className="mt-2 text-sm text-muted leading-relaxed">

--- a/src/components/viewer/sections/DataVisualization.tsx
+++ b/src/components/viewer/sections/DataVisualization.tsx
@@ -55,7 +55,7 @@ function StaircaseChart({ data }: { data: Array<Record<string, string | number>>
                 minWidth: "120px",
               }}
             >
-              <span className="text-sm font-semibold text-white leading-tight pr-2 drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]">
+              <span className="text-sm font-bold text-white leading-tight pr-2 drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]">
                 {item.label}
               </span>
               <span className="text-sm font-bold text-white whitespace-nowrap drop-shadow-[0_1px_2px_rgba(0,0,0,0.35)]">
@@ -89,7 +89,7 @@ function renderCalloutText(text: string) {
   const parts = text.split(/\*\*(.*?)\*\*/g);
   return parts.map((part, i) =>
     i % 2 === 1 ? (
-      <strong key={i} className="font-semibold">
+      <strong key={i} className="font-bold">
         {part}
       </strong>
     ) : (

--- a/src/components/viewer/sections/ExpandableCardGrid.tsx
+++ b/src/components/viewer/sections/ExpandableCardGrid.tsx
@@ -47,7 +47,7 @@ function Card({
       >
         {/* Header */}
         <div className="flex-1">
-          <h3 className="text-lg font-semibold">{card.title}</h3>
+          <h3 className="text-lg font-bold">{card.title}</h3>
           <p className={cn("mt-2 text-sm text-muted leading-relaxed", isQuote && "italic")}>
             {card.summary}
           </p>
@@ -109,7 +109,7 @@ function Card({
       {/* Header */}
       <div className="flex items-start justify-between">
         <div className="flex-1">
-          <h3 className="text-lg font-semibold">{card.title}</h3>
+          <h3 className="text-lg font-bold">{card.title}</h3>
           <p className={cn("mt-2 text-sm text-muted leading-relaxed", isQuote && "italic")}>
             {card.summary}
           </p>

--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -349,7 +349,7 @@ function TimelineTrack({
                       className={cn(
                         "mt-0.5 max-w-[80px] text-center text-[9px] leading-tight transition-colors whitespace-nowrap",
                         isActive
-                          ? "font-semibold"
+                          ? "font-bold"
                           : "text-muted opacity-50"
                       )}
                       style={isActive ? { color } : {}}
@@ -392,7 +392,7 @@ function DetailPanel({
       <div className="mb-3 flex flex-wrap items-start gap-3">
         {/* Day pill */}
         <span
-          className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold"
+          className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
           style={{ backgroundColor: color + "22", color }}
         >
           {/^(Mo|Day|Week|Month|Year|Q\d)/i.test(event.label)
@@ -440,7 +440,7 @@ function DetailPanel({
           }}
         >
           <div
-            className="mb-1 text-[10px] font-mono font-semibold uppercase tracking-widest"
+            className="mb-1 text-[10px] font-mono font-medium uppercase tracking-widest"
             style={{ color }}
           >
             {event.trigger.label}
@@ -454,7 +454,7 @@ function DetailPanel({
       {/* Spend delta */}
       {event.spend_delta && (
         <div
-          className="mt-3 text-xs font-semibold"
+          className="mt-3 text-xs font-medium"
           style={{ color: "var(--palette-accent2, #7c6df0)" }}
         >
           {event.spend_delta} self-serve spend this event
@@ -549,7 +549,7 @@ export function GuidedJourney({
             disabled={isPlaying}
             aria-label="Play journey"
             className={cn(
-              "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-all",
+              "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all",
               isPlaying
                 ? "opacity-50 cursor-not-allowed bg-card border border-border text-muted"
                 : "bg-[var(--palette-accent1,#2fd8c8)] text-background hover:opacity-90"

--- a/src/components/viewer/sections/HubMockup.tsx
+++ b/src/components/viewer/sections/HubMockup.tsx
@@ -111,7 +111,7 @@ function LayeredView({ layers, description }: { layers: HubMockupLayer[]; descri
               viewport={{ once: true, margin: "-30px" }}
             >
               <p
-                className="text-xs font-semibold uppercase tracking-wider mb-3"
+                className="text-xs font-medium uppercase tracking-wider mb-3"
                 style={{ color }}
               >
                 {layer.label}
@@ -195,7 +195,7 @@ export function HubMockup({
 
             {connections && connections.length > 0 && (
               <div className="mt-6 rounded-xl border border-border bg-surface p-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">
+                <p className="text-xs font-medium uppercase tracking-wider text-muted mb-3">
                   Connections
                 </p>
                 <div className="grid gap-2 md:grid-cols-2">

--- a/src/components/viewer/sections/RichTextCollapsible.tsx
+++ b/src/components/viewer/sections/RichTextCollapsible.tsx
@@ -41,7 +41,7 @@ export function RichTextCollapsible({
     <div>
       {content.tag && (
         <span
-          className="mb-3 inline-block rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider"
+          className="mb-3 inline-block rounded-full px-3 py-1 text-xs font-medium uppercase tracking-wider"
           style={{
             color: content.tag.color || "var(--palette-accent1, var(--color-accent))",
             backgroundColor: `color-mix(in srgb, ${content.tag.color || "var(--palette-accent1, var(--color-accent))"} 12%, transparent)`,

--- a/src/components/viewer/sections/TierTable.tsx
+++ b/src/components/viewer/sections/TierTable.tsx
@@ -143,7 +143,7 @@ function TierCard({
       )}
     >
       {highlighted && (
-        <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-accent px-3 py-0.5 text-xs font-semibold text-white">
+        <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-accent px-3 py-0.5 text-xs font-medium text-white">
           Recommended
         </div>
       )}
@@ -167,7 +167,7 @@ function TierCard({
       {column.cta && (
         <button
           className={cn(
-            "mt-6 w-full rounded-lg py-2.5 text-sm font-semibold transition-colors",
+            "mt-6 w-full rounded-lg py-2.5 text-sm font-medium transition-colors",
             highlighted
               ? "bg-accent text-white hover:bg-accent-hover"
               : "bg-card-hover text-foreground hover:bg-border"
@@ -187,7 +187,7 @@ function TierCard({
                 <X className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
               )
             ) : (
-              <span className="mt-0.5 text-xs font-semibold text-accent shrink-0">
+              <span className="mt-0.5 text-xs font-medium text-accent shrink-0">
                 {feature.included}
               </span>
             )}


### PR DESCRIPTION
## What changed
20 instances of `font-semibold` (not in design-system scale) replaced across 10 viewer files:

| File | Element type | Old → New |
|------|-------------|----------|
| `SidebarNav.tsx` | `h2` heading | `font-semibold` → `font-bold` |
| `StrataFooter.tsx` | `p.text-lg` heading | `font-semibold` → `font-bold` |
| `StrataFooter.tsx` | CTA button `a` | `font-semibold` → `font-medium` |
| `FormattedText.tsx` | `<strong>` inline | `font-semibold` → `font-bold` |
| `DataVisualization.tsx` | Chart bar label `span` | `font-semibold` → `font-bold` (aligns with adjacent amount which used `font-bold`) |
| `DataVisualization.tsx` | `<strong>` inline | `font-semibold` → `font-bold` |
| `HubMockup.tsx` | Uppercase layer label `p` | `font-semibold` → `font-medium` |
| `HubMockup.tsx` | Uppercase "Connections" label `p` | `font-semibold` → `font-medium` |
| `AnimatedTimeline.tsx` | Uppercase step label `span` | `font-semibold` → `font-medium` |
| `AnimatedTimeline.tsx` | `h3` step title | `font-semibold` → `font-bold` |
| `ExpandableCardGrid.tsx` | `h3` card title (×2) | `font-semibold` → `font-bold` |
| `RichTextCollapsible.tsx` | Tag badge pill | `font-semibold` → `font-medium` |
| `TierTable.tsx` | "Recommended" badge pill | `font-semibold` → `font-medium` |
| `TierTable.tsx` | CTA button | `font-semibold` → `font-medium` |
| `TierTable.tsx` | Feature qualifier `span` | `font-semibold` → `font-medium` |
| `GuidedJourney.tsx` | Active state nav label | `font-semibold` → `font-bold` |
| `GuidedJourney.tsx` | Day pill badge | `font-semibold` → `font-medium` |
| `GuidedJourney.tsx` | Mono uppercase label | `font-semibold` → `font-medium` |
| `GuidedJourney.tsx` | Spend delta text | `font-semibold` → `font-medium` |
| `GuidedJourney.tsx` | Play button | `font-semibold` → `font-medium` |

## Why
Design system typography scale defines exactly: `font-bold` (headings, section titles) and `font-medium` (buttons, labels). `font-semibold` is not approved and creates visual weight inconsistency across the investor-facing viewer surface.

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Weights section.

## Files modified
- `src/components/viewer/SidebarNav.tsx`
- `src/components/viewer/StrataFooter.tsx`
- `src/components/viewer/FormattedText.tsx`
- `src/components/viewer/sections/HubMockup.tsx`
- `src/components/viewer/sections/DataVisualization.tsx`
- `src/components/viewer/sections/AnimatedTimeline.tsx`
- `src/components/viewer/sections/ExpandableCardGrid.tsx`
- `src/components/viewer/sections/RichTextCollapsible.tsx`
- `src/components/viewer/sections/TierTable.tsx`
- `src/components/viewer/sections/GuidedJourney.tsx`

## Tier
**Tier 0** — Typography token normalization. No behavior change.