### PR TITLE
Normalize font-semibold to font-medium in auth component buttons

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -175,7 +175,7 @@ export function AuthModal({ open, onClose, redirectTo }: AuthModalProps) {
                 onClick={handleMagicLink}
                 disabled={!email.trim() || loading}
                 className={cn(
-                  "flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold transition-all",
+                  "flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-medium transition-all",
                   email.trim() && !loading
                     ? "bg-accent text-white hover:bg-accent-hover"
                     : "bg-card text-muted cursor-not-allowed"

--- a/src/components/auth/UpgradePrompt.tsx
+++ b/src/components/auth/UpgradePrompt.tsx
@@ -87,7 +87,7 @@ export function UpgradePrompt({
           {/* For now, link to a waitlist or Stripe checkout */}
           <a
             href="mailto:jon@sharestrata.com?subject=Strata%20Pro%20-%20Founding%20Member&body=I%27d%20like%20to%20upgrade%20to%20Strata%20Pro%20as%20a%20founding%20member."
-            className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-white hover:bg-accent-hover transition-colors"
+            className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-4 py-3 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
           >
             <Sparkles className="h-4 w-4" />
             Become a founding member


### PR DESCRIPTION
## What changed
Replaced `font-semibold` with `font-medium` on the primary CTA buttons in 2 auth components:
- `UpgradePrompt.tsx`: "Get founding member access" link button
- `AuthModal.tsx`: Email submit button

## Why
Design system: buttons use `font-medium`, not `font-semibold`. `font-semibold` is not in the approved weight scale.

## Rubric item
Off-rubric discovery. Design-system reference: Buttons section and Typography → Weights.

## Files modified
- `src/components/auth/UpgradePrompt.tsx`
- `src/components/auth/AuthModal.tsx`

## Tier
**Tier 0** — Typography token normalization. No behavior change.