### PR TITLE
Normalize font-semibold in create and dashboard pages

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -210,7 +210,7 @@ export default function CreatePage() {
 
           <div className="flex items-center gap-2">
             <Layers className="h-5 w-5 text-accent" />
-            <span className="font-semibold">Create Artifact</span>
+            <span className="font-bold">Create Artifact</span>
           </div>
 
           <div className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -268,7 +268,7 @@ export default function CreatePage() {
                     "border-border bg-card hover:border-accent/40 hover:bg-card-hover"
                   )}
                 >
-                  <h3 className="text-lg font-semibold group-hover:text-accent transition-colors">
+                  <h3 className="text-lg font-bold group-hover:text-accent transition-colors">
                     {TEMPLATE_LABELS[type]}
                   </h3>
                   <p className="mt-2 text-sm text-muted leading-relaxed">
@@ -410,7 +410,7 @@ export default function CreatePage() {
                 onClick={handleStructure}
                 disabled={!content.trim() || isStructuring}
                 className={cn(
-                  "flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold transition-all",
+                  "flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-medium transition-all",
                   content.trim() && !isStructuring
                     ? "bg-accent text-white hover:bg-accent-hover"
                     : "bg-card text-muted cursor-not-allowed"
@@ -461,7 +461,7 @@ export default function CreatePage() {
                 <button
                   onClick={handlePublish}
                   disabled={isPublishing}
-                  className="flex items-center gap-2 rounded-xl bg-accent px-6 py-2.5 text-sm font-semibold text-white hover:bg-accent-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="flex items-center gap-2 rounded-xl bg-accent px-6 py-2.5 text-sm font-medium text-white hover:bg-accent-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                 >
                   {isPublishing ? (
                     <>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -97,7 +97,7 @@ export default function DashboardPage() {
         <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
           <Link href="/" className="flex items-center gap-2">
             <Layers className="h-5 w-5 text-accent" />
-            <span className="font-semibold">Strata</span>
+            <span className="font-bold">Strata</span>
           </Link>
 
           <div className="flex items-center gap-4">
@@ -125,7 +125,7 @@ export default function DashboardPage() {
             </p>
             <Link
               href="/create"
-              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-accent px-6 py-3 text-sm font-semibold text-white hover:bg-accent-hover transition-colors"
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-accent px-6 py-3 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
             >
               <Plus className="h-4 w-4" />
               Create your first artifact


### PR DESCRIPTION
## What changed

**`create/page.tsx`** (4 instances):
- `<span>Create Artifact</span>` nav logo title: `font-semibold` → `font-bold`
- `<h3>` template selector heading: `font-semibold` → `font-bold`
- Structure button: `font-semibold` → `font-medium`
- Publish button: `font-semibold` → `font-medium`

**`dashboard/page.tsx`** (2 instances):
- `<span>Strata</span>` nav brand name: `font-semibold` → `font-bold`
- Create new document button: `font-semibold` → `font-medium`

## Why
Design system: `font-bold` for headings/titles, `font-medium` for buttons. `font-semibold` is not in the approved weight scale.

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Weights and Buttons sections.

## Files modified
- `src/app/create/page.tsx`
- `src/app/dashboard/page.tsx`

## Tier
**Tier 0** — Typography token normalization. No behavior change.