### PR TITLE
Add missing transition-colors to image error dismiss button in EditorLayout

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -597,7 +597,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
             <div className="sticky top-0 z-20 mx-auto max-w-4xl px-6 pt-3">
               <div className="flex items-center gap-2 rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-2.5 text-sm text-red-400">
                 <span className="flex-1">{imageError}</span>
-                <button onClick={() => setImageError(null)} className="text-red-400/60 hover:text-red-400">
+                <button onClick={() => setImageError(null)} className="text-red-400/60 hover:text-red-400 transition-colors">
                   <XIcon className="w-4 h-4" />
                 </button>
               </div>


### PR DESCRIPTION
## What changed
Added `transition-colors` to the X button that dismisses the image upload error in `EditorLayout.tsx`. The button had `hover:text-red-400` but was missing the transition class.

## Why
Design system Animations section: all color changes require `transition-colors`. The button changes color on hover but had no transition, causing an abrupt snap instead of a smooth fade.

## Rubric item
Off-rubric discovery. Design-system reference: Animations → Required Transitions.

## Files modified
- `src/components/editor/EditorLayout.tsx` (1 line)

## Tier
**Tier 0** — Missing animation token. No behavior change.