### PR TITLE
Add transition-opacity to drag handle buttons in SortableSectionList and ItemManager

### DIFF
--- a/src/components/editor/ItemManager.tsx
+++ b/src/components/editor/ItemManager.tsx
@@ -60,7 +60,7 @@ function SortableRow({
       <button
         {...attributes}
         {...listeners}
-        className="mt-3 opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none"
+        className="mt-3 opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none transition-opacity"
         tabIndex={-1}
       >
         <GripVertical className="w-3.5 h-3.5" />

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -114,7 +114,7 @@ function SortableItem({
       <button
         {...attributes}
         {...listeners}
-        className="opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none"
+        className="opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none transition-opacity"
       >
         <GripVertical className="w-3.5 h-3.5" />
       </button>


### PR DESCRIPTION
## What changed
Added `transition-opacity` to the drag-handle grip buttons in `SortableSectionList.tsx` and `ItemManager.tsx`. Both had `opacity-0 group-hover:opacity-50` but were missing the transition class.

## Why
Design system Animations section: "Layout changes: `transition-all`". The opacity change on drag handles was abrupt — a hard snap from invisible to semi-visible. With `transition-opacity` the fade-in is smooth.

## Rubric item
Off-rubric discovery. Design-system reference: Animations → Required Transitions.

## Files modified
- `src/components/editor/SortableSectionList.tsx` (1 line)
- `src/components/editor/ItemManager.tsx` (1 line)

## Tier
**Tier 0** — Missing animation token. No behavior change.