### PR TITLE
Add focus ring to GuidedJourney timeline node buttons

### DIFF
--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -283,7 +283,7 @@ function TimelineTrack({
                   key={event.id}
                   data-index={i}
                   onClick={() => onSelect(i)}
-                  className="group absolute flex flex-col items-center focus:outline-none"
+                  className="group absolute flex flex-col items-center focus:outline-none focus:ring-2 focus:ring-accent/50 rounded"
                   style={{
                     left: `${leftPct}%`,
                     top: 0,


### PR DESCRIPTION
## What changed
Timeline node buttons in `GuidedJourney.tsx` had `focus:outline-none` to suppress the browser default outline, but nothing replaced it — making keyboard focus invisible on these elements.

Added `focus:ring-2 focus:ring-accent/50 rounded` to provide a custom accessible focus indicator that matches the design system accent ring pattern.

## Why
Design system accessibility minimums: "All interactive elements: focusable via Tab." Removing the default outline without a replacement violates WCAG 2.4.7 (focus visible). This is an investor-facing viewer component, so accessibility matters for credibility.

## Rubric item
Off-rubric discovery. Design-system reference: Accessibility Minimums → Keyboard section.

## Files modified
- `src/components/viewer/sections/GuidedJourney.tsx` (1 line)

## Tier
**Tier 1** — Visual polish. Adds a visible focus ring on keyboard navigation. No behavior change, no layout change.