### PR TITLE
Normalize font-semibold to font-bold in discover page headings

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -135,7 +135,7 @@ export default function DiscoverPage() {
               <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-accent/10 mb-6">
                 <Check className="w-5 h-5 text-accent" />
               </div>
-              <h2 className="text-xl font-semibold mb-3">
+              <h2 className="text-xl font-bold mb-3">
                 You&apos;re on the list
               </h2>
               <p className="text-muted text-sm max-w-md mx-auto">
@@ -146,7 +146,7 @@ export default function DiscoverPage() {
             </motion.div>
           ) : (
             <>
-              <h2 className="text-xl font-semibold mb-2">
+              <h2 className="text-xl font-bold mb-2">
                 Interested?
               </h2>
               <p className="text-muted text-sm mb-8 max-w-md">


### PR DESCRIPTION
## What changed
Two `h2` elements on `/discover` used `font-semibold`, which is not in the design system weight scale.

## Why
Design system allows only `font-bold` (headings) and `font-medium` (labels/buttons). `font-semibold` is not a permitted weight.

## Files modified
- `src/app/discover/page.tsx` — 2 instances changed

## Rubric item
Off-rubric discovery. Font-semibold normalization pattern from design-system.md typography section.

## Tier
Tier 0 — token-only change (weight class swap), no behavior change.