### PR TITLE
Add aria-label to unlabeled color pickers and connection selects in editor

### DIFF
--- a/src/components/editor/DocumentSettings.tsx
+++ b/src/components/editor/DocumentSettings.tsx
@@ -96,6 +96,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
               onChange={(e) => handlePrimaryChange(e.target.value)}
               className="w-8 h-8 rounded cursor-pointer border border-white/20"
               title="Primary color"
+              aria-label="Primary color"
             />
             <span className="text-xs text-muted-foreground">Primary</span>
           </div>
@@ -107,6 +108,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
               onChange={(e) => handleSecondaryChange(e.target.value)}
               className="w-8 h-8 rounded cursor-pointer border border-white/20"
               title="Secondary color"
+              aria-label="Secondary color"
             />
             <span className="text-xs text-muted-foreground">Secondary</span>
           </div>

--- a/src/components/editor/EditableGuidedJourney.tsx
+++ b/src/components/editor/EditableGuidedJourney.tsx
@@ -145,6 +145,7 @@ function PhasesEditor({
               onFieldChange(`content.phases.${i}.color`, e.target.value)
             }
             className="w-6 h-6 rounded cursor-pointer border-0 bg-transparent shrink-0"
+            aria-label={`Phase color for ${phase.name || `Phase ${i + 1}`}`}
           />
           <div className="flex-1 min-w-[120px]">
             <InlineEditor

--- a/src/components/editor/EditableHubMockup.tsx
+++ b/src/components/editor/EditableHubMockup.tsx
@@ -147,6 +147,7 @@ export function EditableHubMockup({
                     e.target.value
                   )
                 }
+                aria-label="Connection source node"
                 className="bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50"
               >
                 {allNodes.map((n) => (
@@ -164,6 +165,7 @@ export function EditableHubMockup({
                     e.target.value
                   )
                 }
+                aria-label="Connection target node"
                 className="bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50"
               >
                 {allNodes.map((n) => (
@@ -338,6 +340,7 @@ function NodeEditor({
         value={node.color || "#6366f1"}
         onChange={(e) => onFieldChange(`${prefix}.color`, e.target.value)}
         className="w-6 h-6 rounded cursor-pointer border-0 bg-transparent mt-0.5"
+        aria-label={`Node color for ${node.label || "node"}`}
       />
       <div className="flex-1 min-w-0 space-y-1">
         <InlineEditor


### PR DESCRIPTION
## What changed
Four color picker `<input type="color">` elements and two `<select>` elements were missing `aria-label`, making them inaccessible to screen readers.

## Why
Design system accessibility minimums require all form inputs to have an associated `<label>` or `aria-label`. These inputs had neither (or only a `title` attribute which is insufficient for screen readers).

## Fixes
- `DocumentSettings.tsx`: primary and secondary color pickers — had `title` attribute but no `aria-label`
- `EditableGuidedJourney.tsx`: phase color picker — no label at all; now uses dynamic `aria-label` with phase name
- `EditableHubMockup.tsx`: node color picker — no label; selects for connection "from" and "to" nodes — no label

## Files modified
- `src/components/editor/DocumentSettings.tsx`
- `src/components/editor/EditableGuidedJourney.tsx`
- `src/components/editor/EditableHubMockup.tsx`

## Tier
Tier 0 — accessibility attribute only, no visual change.