### PR TITLE
Add aria-label to icon-only close buttons in auth modals

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -75,6 +75,7 @@ export function AuthModal({ open, onClose, redirectTo }: AuthModalProps) {
       <div className="relative w-full max-w-md rounded-2xl border border-border bg-background p-8 shadow-2xl">
         <button
           onClick={onClose}
+          aria-label="Close"
           className="absolute right-4 top-4 text-muted hover:text-foreground transition-colors"
         >
           <X className="h-5 w-5" />

--- a/src/components/auth/UpgradePrompt.tsx
+++ b/src/components/auth/UpgradePrompt.tsx
@@ -37,6 +37,7 @@ export function UpgradePrompt({
       <div className="relative w-full max-w-lg rounded-2xl border border-border bg-background p-8 shadow-2xl">
         <button
           onClick={onClose}
+          aria-label="Close"
           className="absolute right-4 top-4 text-muted hover:text-foreground transition-colors"
         >
           <X className="h-5 w-5" />


### PR DESCRIPTION
## What changed
Added `aria-label="Close"` to the X close buttons in two auth modal components:
- `AuthModal.tsx`
- `UpgradePrompt.tsx`

## Why
Icon-only buttons (containing only an `<X />` icon, no visible text) must have `aria-label` per the design system accessibility minimums: "All icon-only buttons: `aria-label="[action]"`". Screen readers would announce these as "button" with no context otherwise.

## Rubric item
Off-rubric discovery. Design-system reference: Accessibility Minimums → Required ARIA.

## Files modified
- `src/components/auth/AuthModal.tsx`
- `src/components/auth/UpgradePrompt.tsx`

## Tier
**Tier 0** — ARIA attribute addition. No behavior change, no visual change.