### PR TITLE
Normalize loading opacity from 50 to 30 in AuthModal Google button

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -125,7 +125,7 @@ export function AuthModal({ open, onClose, redirectTo }: AuthModalProps) {
               className={cn(
                 "mt-6 flex w-full items-center justify-center gap-3 rounded-xl border border-border bg-card px-4 py-3 text-sm font-medium transition-colors",
                 loading
-                  ? "cursor-not-allowed opacity-50"
+                  ? "cursor-not-allowed opacity-30"
                   : "hover:bg-card-hover"
               )}
             >


### PR DESCRIPTION
## What changed
Changed `opacity-50` to `opacity-30` on the Google OAuth button when it is in its loading/disabled state in `AuthModal.tsx`.

## Why
Design system disabled state spec: `disabled:opacity-30 disabled:cursor-not-allowed`. The Google button uses a conditional class for loading rather than the `disabled:` variant — but the opacity value should still be `30`, not `50`. `50` was inconsistent with the rest of the design system.

## Rubric item
Off-rubric discovery. Design-system reference: Interactive States → Disabled State (all buttons).

## Files modified
- `src/components/auth/AuthModal.tsx` (1 line)

## Tier
**Tier 0** — Single token value change. No behavior change.