### PR TITLE
Add aria-hidden to decorative SVGs in editor and viewer

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -132,7 +132,7 @@ export function AuthModal({ open, onClose, redirectTo }: AuthModalProps) {
               {loading ? (
                 <Loader2 className="h-5 w-5 animate-spin" />
               ) : (
-                <svg className="h-5 w-5" viewBox="0 0 24 24">
+                <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
                     fill="#4285F4"

--- a/src/components/editor/SectionTypePreview.tsx
+++ b/src/components/editor/SectionTypePreview.tsx
@@ -9,7 +9,7 @@ interface SectionTypePreviewProps {
 export function SectionTypePreview({ type }: SectionTypePreviewProps) {
   return (
     <div className="w-full h-[56px] rounded bg-white/5 flex items-center justify-center overflow-hidden">
-      <svg viewBox="0 0 120 56" className="w-full h-full" fill="none">
+      <svg viewBox="0 0 120 56" className="w-full h-full" fill="none" aria-hidden="true">
         {previews[type]}
       </svg>
     </div>

--- a/src/components/viewer/sections/HubMockup.tsx
+++ b/src/components/viewer/sections/HubMockup.tsx
@@ -71,7 +71,7 @@ function LayerArrow({ index, label }: { index: number; label?: string }) {
       viewport={{ once: true }}
       className="flex flex-col items-center py-3 gap-1"
     >
-      <svg width="32" height="48" viewBox="0 0 32 48" className="text-accent/50">
+      <svg width="32" height="48" viewBox="0 0 32 48" className="text-accent/50" aria-hidden="true">
         <line
           x1="16" y1="0" x2="16" y2="38"
           stroke="currentColor"


### PR DESCRIPTION
## What changed
Added aria-hidden="true" to three decorative SVG elements.

- SectionTypePreview.tsx: preview thumbnail SVG (pure decoration)
- AuthModal.tsx: Google brand logo SVG inside the Continue with Google button (button already has text label)
- HubMockup.tsx: connector arrow SVG between hub nodes (structural decoration)

## Why
Screen readers attempt to announce SVG elements without aria-hidden or title. These three SVGs are purely decorative and their announcement would confuse users.

## Rubric item
Off-rubric discovery. Design-system reference: Accessibility Minimums.

## Files modified
- src/components/editor/SectionTypePreview.tsx
- src/components/auth/AuthModal.tsx
- src/components/viewer/sections/HubMockup.tsx

## Tier
Tier 0 — Attribute addition only. No visual or behavior change.