### PR TITLE
Normalize label typography and input focus ring in EditableDataViz

### DIFF
--- a/src/components/editor/EditableDataViz.tsx
+++ b/src/components/editor/EditableDataViz.tsx
@@ -79,7 +79,7 @@ export function EditableDataViz({
 
       {/* Data table */}
       <div>
-        <div className="flex items-center gap-3 mb-2 text-xs text-muted-foreground uppercase tracking-wider">
+        <div className="flex items-center gap-3 mb-2 text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
           <span className="flex-1 pl-8">{xKey}</span>
           <span className="w-36">{yKey}</span>
         </div>
@@ -112,7 +112,7 @@ export function EditableDataViz({
                       e.target.value
                     )
                   }
-                  className="w-full bg-white/5 border border-white/10 rounded px-2 py-1 text-sm text-right"
+                  className="w-full bg-white/5 border border-white/10 rounded px-2 py-1 text-sm text-right focus:outline-none focus:ring-1 focus:ring-accent/50"
                 />
               </div>
             </div>
@@ -122,7 +122,7 @@ export function EditableDataViz({
 
       {/* Description */}
       <div>
-        <label className="text-xs text-muted-foreground uppercase tracking-wider mb-1 block">
+        <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1 block">
           Description
         </label>
         <InlineEditor
@@ -135,7 +135,7 @@ export function EditableDataViz({
 
       {/* Callout */}
       <div>
-        <label className="text-xs text-muted-foreground uppercase tracking-wider mb-1 block">
+        <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1 block">
           Callout
         </label>
         <InlineEditor


### PR DESCRIPTION
## What changed
- `text-xs` → `text-[10px]` on data table column headers and Description/Callout section labels
- `tracking-wider` → `tracking-wide` (design-system label pattern uses `tracking-wide`)
- Added `font-medium` to match label voice pattern
- Added `focus:outline-none focus:ring-1 focus:ring-accent/50` to the data point value `<input>` (was missing a focus ring entirely)

## Why
Design-system label pattern is `text-[10px] font-medium text-muted-foreground uppercase tracking-wide`. `EditableDataViz` was using `text-xs` and `tracking-wider` — two minor deviations that break the unified label voice across editor panels.

The data-point value input had no focus ring, violating the focus ring requirement for all form inputs.

## Rubric item
Discovery (no rubric number) — label typography normalization

## Files modified
- `src/components/editor/EditableDataViz.tsx`

## Tier
Tier 0 — token-only changes. No behavior change possible.