### PR TITLE
Add disabled:cursor-not-allowed to editor buttons missing it

### DIFF
--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -171,7 +171,7 @@ export function AiChatPanel({
           <button
             onClick={handleSend}
             disabled={!input.trim() || isLoading}
-            className="p-2 text-muted-foreground hover:text-accent disabled:opacity-30 disabled:hover:text-muted-foreground transition-colors shrink-0"
+            className="p-2 text-muted-foreground hover:text-accent disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-muted-foreground transition-colors shrink-0"
           >
             <Send className="w-4 h-4" />
           </button>

--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -204,7 +204,7 @@ function SectionImagePreview({
           <button
             onClick={handleExtractStructure}
             disabled={isExtracting}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isExtracting ? (
               <Loader2 className="w-3 h-3 animate-spin" />

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -537,7 +537,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                       <button
                         onClick={() => fileInputRef.current?.click()}
                         disabled={isProcessingImage}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <ImageIcon className="w-4 h-4" />
                         {isProcessingImage ? "Processing..." : "Add from Image"}

--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -113,7 +113,7 @@ export function LogoUpload({
         <button
           onClick={handleRemove}
           disabled={uploading}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <X className="h-3 w-3" />
           {uploading ? "Removing..." : "Remove"}

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -333,7 +333,7 @@ export function SplitViewLayout({
                           handleCloseSidebarOverlay();
                         }}
                         disabled={isProcessingImage}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <ImageIcon className="w-4 h-4" />
                         {isProcessingImage ? "Processing..." : "Add from Image"}

--- a/src/components/editor/TypeSelectorDropdown.tsx
+++ b/src/components/editor/TypeSelectorDropdown.tsx
@@ -119,7 +119,7 @@ export function TypeSelectorDropdown({
       <button
         onClick={() => !isLoading && setIsOpen((v) => !v)}
         disabled={isLoading}
-        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {isLoading ? (
           <>


### PR DESCRIPTION
## What changed
Added `disabled:cursor-not-allowed` to 6 buttons in editor components that had `disabled:opacity-*` but were missing the cursor rule.

## Why
Design-system disabled pattern: `disabled:opacity-30 disabled:cursor-not-allowed`. All 6 buttons showed opacity feedback when disabled but the cursor stayed as a pointer, giving users no visual signal that the button is unavailable.

## Files modified
- `SplitViewLayout.tsx` — image upload button
- `EditorLayout.tsx` — image upload button (EditorLayout mirror)
- `AiChatPanel.tsx` — send button (already had opacity-30; cursor was missing)
- `EditableSectionRenderer.tsx` — extract structure button
- `TypeSelectorDropdown.tsx` — type change trigger
- `LogoUpload.tsx` — remove logo button

## Note
This PR does NOT change `disabled:opacity-50 → disabled:opacity-30` (that is tracked separately in PR #21). Only cursor-not-allowed is added here.

## Tier
Tier 0 — token-only. No behavior change.