### PR TITLE
Normalize tracking-wider to tracking-wide in viewer section labels

### DIFF
--- a/src/components/viewer/sections/AnimatedTimeline.tsx
+++ b/src/components/viewer/sections/AnimatedTimeline.tsx
@@ -64,7 +64,7 @@ function VerticalStep({
 
       {/* Content */}
       <div className={cn("pb-10", isLast && "pb-0")}>
-        <span className="text-xs font-semibold uppercase tracking-wider text-accent">
+        <span className="text-xs font-semibold uppercase tracking-wide text-accent">
           {step.label}
         </span>
         <h3 className={cn("mt-1 text-lg font-semibold", styles.text)}>

--- a/src/components/viewer/sections/HubMockup.tsx
+++ b/src/components/viewer/sections/HubMockup.tsx
@@ -111,7 +111,7 @@ function LayeredView({ layers, description }: { layers: HubMockupLayer[]; descri
               viewport={{ once: true, margin: "-30px" }}
             >
               <p
-                className="text-xs font-semibold uppercase tracking-wider mb-3"
+                className="text-xs font-semibold uppercase tracking-wide mb-3"
                 style={{ color }}
               >
                 {layer.label}
@@ -195,7 +195,7 @@ export function HubMockup({
 
             {connections && connections.length > 0 && (
               <div className="mt-6 rounded-xl border border-border bg-surface p-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted mb-3">
                   Connections
                 </p>
                 <div className="grid gap-2 md:grid-cols-2">

--- a/src/components/viewer/sections/RichTextCollapsible.tsx
+++ b/src/components/viewer/sections/RichTextCollapsible.tsx
@@ -41,7 +41,7 @@ export function RichTextCollapsible({
     <div>
       {content.tag && (
         <span
-          className="mb-3 inline-block rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider"
+          className="mb-3 inline-block rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide"
           style={{
             color: content.tag.color || "var(--palette-accent1, var(--color-accent))",
             backgroundColor: `color-mix(in srgb, ${content.tag.color || "var(--palette-accent1, var(--color-accent))"} 12%, transparent)`,


### PR DESCRIPTION
## What changed
4 instances of `tracking-wider` replaced with `tracking-wide` across 3 viewer section components:

| File | Element | Location |
|------|---------|----------|
| `HubMockup.tsx` | Layer label `p` | line 114 |
| `HubMockup.tsx` | "Connections" label `p` | line 198 |
| `AnimatedTimeline.tsx` | Step label `span` | line 67 |
| `RichTextCollapsible.tsx` | Tag badge pill `span` | line 44 |

## Why
Design system Typography label pattern specifies `tracking-wide`. These 4 elements are uppercase label-voice text and were using `tracking-wider` (one step above spec).

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Label Pattern (`tracking-wide`).

## Files modified
- `src/components/viewer/sections/HubMockup.tsx`
- `src/components/viewer/sections/AnimatedTimeline.tsx`
- `src/components/viewer/sections/RichTextCollapsible.tsx`

## Tier
**Tier 0** — Token value normalization. No behavior change.

Note: `font-semibold` in these same elements is addressed separately by open PR #50.