### PR TITLE
Normalize tracking-wider to tracking-wide in dashboard section heading

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -192,7 +192,7 @@ function ArtifactSection({
 }) {
   return (
     <div>
-      <h2 className="text-sm font-medium text-muted uppercase tracking-wider">
+      <h2 className="text-sm font-medium text-muted uppercase tracking-wide">
         {title} ({count})
       </h2>
       <div className="mt-3 space-y-2">


### PR DESCRIPTION
## What changed
1 instance of `tracking-wider` replaced with `tracking-wide` in the dashboard page section group heading.

| File | Element | Location |
|------|---------|----------|
| `src/app/dashboard/page.tsx` | `DocumentStatusGroup` h2 label | line 195 |

## Why
Design system Typography label pattern specifies `tracking-wide`. The uppercase section heading in the dashboard was using `tracking-wider` (one step above spec).

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Label Pattern (`tracking-wide`).

## Files modified
- `src/app/dashboard/page.tsx`

## Tier
**Tier 0** — Token value normalization. No behavior change.