### PR TITLE
Normalize tracking-wider to tracking-wide in discover page section label

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -99,7 +99,7 @@ export default function DiscoverPage() {
           transition={{ duration: 0.6, delay: 0.3 }}
           className="py-12 border-t border-white/10"
         >
-          <p className="text-sm text-muted-foreground uppercase tracking-wider mb-8">
+          <p className="text-sm text-muted-foreground uppercase tracking-wide mb-8">
             What you experienced
           </p>
           <div className="grid sm:grid-cols-2 gap-x-12 gap-y-4">


### PR DESCRIPTION
## What changed
1 instance of `tracking-wider` replaced with `tracking-wide` in the discover page.

| File | Element | Location |
|------|---------|----------|
| `src/app/discover/page.tsx` | Section label `p` ("What you experienced") | line 102 |

## Why
Design system Typography label pattern specifies `tracking-wide`. This uppercase section label was using `tracking-wider` — one step above spec.

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Label Pattern (`tracking-wide`).

## Files modified
- `src/app/discover/page.tsx`

## Tier
**Tier 0** — Token value normalization. No behavior change.