### PR TITLE
Normalize bg-accent/15 to bg-accent/20 in AiChatPanel user message bubble

### DIFF
--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -211,7 +211,7 @@ function MessageBubble({
         <div
           className={`rounded-lg px-3 py-2 text-sm ${
             isUser
-              ? "bg-accent/15 text-foreground"
+              ? "bg-accent/20 text-foreground"
               : "bg-white/5 text-foreground"
           }`}
         >


### PR DESCRIPTION
## What changed
User message bubble background in `AiChatPanel.tsx` changed from `bg-accent/15` to `bg-accent/20`.

## Why
Design system opacity scale defines: `bg-accent/5`, `bg-accent/10`, `bg-accent/20` — no `/15` exists. `bg-accent/20` is the approved value for selected/active state fills and is the closest compliant value for a user-sent message bubble.

## Rubric item
Off-rubric discovery. Design-system reference: Opacity System → Backgrounds.

## Files modified
- `src/components/editor/AiChatPanel.tsx` (line 214)

## Tier
**Tier 0** — Token value normalization. No behavior change. Visual delta is negligible (5% opacity step).