### PR TITLE
Remove non-standard default ring from inline edit inputs in Editable components

### DIFF
--- a/src/components/editor/EditableGuidedJourney.tsx
+++ b/src/components/editor/EditableGuidedJourney.tsx
@@ -237,7 +237,7 @@ function EventsEditor({
                       parseInt(e.target.value) || 0
                     )
                   }
-                  className="w-full bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50"
+                  className="w-full bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none focus:ring-1 focus:ring-accent/50"
                 />
               </div>
               {/* Title */}
@@ -265,7 +265,7 @@ function EventsEditor({
                       e.target.value
                     )
                   }
-                  className="block w-full bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50 truncate"
+                  className="block w-full bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none focus:ring-1 focus:ring-accent/50 truncate"
                   style={{
                     borderLeft: phase
                       ? `3px solid ${phase.color}`

--- a/src/components/editor/EditableHubMockup.tsx
+++ b/src/components/editor/EditableHubMockup.tsx
@@ -147,7 +147,7 @@ export function EditableHubMockup({
                     e.target.value
                   )
                 }
-                className="bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50"
+                className="bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none focus:ring-1 focus:ring-accent/50"
               >
                 {allNodes.map((n) => (
                   <option key={n.id} value={n.id}>
@@ -164,7 +164,7 @@ export function EditableHubMockup({
                     e.target.value
                   )
                 }
-                className="bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50"
+                className="bg-white/10 rounded px-1.5 py-0.5 text-sm outline-none focus:ring-1 focus:ring-accent/50"
               >
                 {allNodes.map((n) => (
                   <option key={n.id} value={n.id}>


### PR DESCRIPTION
## What changed
Removed `ring-1 ring-white/10` (always-visible ring) from 4 inline edit controls, keeping `focus:ring-1 focus:ring-accent/50` for focus state.

| File | Element | Count |
|------|---------|-------|
| `EditableGuidedJourney.tsx` | Day number input, Phase select | 2 |
| `EditableHubMockup.tsx` | Connection from/to selects | 2 |

## Why
Design system Text Input spec: `outline-none focus:ring-1 focus:ring-accent/50` — no default ring. `ring-white/10` is not in the approved ring scale. These inputs were showing a faint white ring at rest that contradicts the spec. The `bg-white/10` background already makes the field boundary visible without a ring.

## Rubric item
Off-rubric discovery. Design-system reference: Form Inputs → Text Input.

## Files modified
- `src/components/editor/EditableGuidedJourney.tsx`
- `src/components/editor/EditableHubMockup.tsx`

## Tier
**Tier 0** — Token normalization. Removes non-standard ring value. No interaction or layout change.

Note: `EditableDataViz.tsx` has the same issue and is addressed in open PR #67.