### PR TITLE
Normalize placeholder opacity to /50 in create page and auth modal inputs

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -316,7 +316,7 @@ export default function CreatePage() {
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
                   placeholder="e.g., Q2 Platform Vision"
-                  className="mt-1 w-full rounded-xl border border-border bg-card px-4 py-3 text-foreground placeholder:text-muted-foreground focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+                  className="mt-1 w-full rounded-xl border border-border bg-card px-4 py-3 text-foreground placeholder:text-muted-foreground/50 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
                 />
               </div>
 
@@ -393,7 +393,7 @@ export default function CreatePage() {
                   onChange={(e) => { setContent(e.target.value); if (pdfFileName) setPdfFileName(null); }}
                   placeholder="Paste your strategy notes, outlines, bullet points, docs — anything you want to turn into an interactive artifact..."
                   rows={16}
-                  className="mt-1 w-full rounded-xl border border-border bg-card px-4 py-3 text-foreground placeholder:text-muted-foreground focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent resize-y font-mono text-sm leading-relaxed"
+                  className="mt-1 w-full rounded-xl border border-border bg-card px-4 py-3 text-foreground placeholder:text-muted-foreground/50 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent resize-y font-mono text-sm leading-relaxed"
                 />
                 <p className="mt-1 text-xs text-muted-foreground">
                   {content.length.toLocaleString()} characters

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -169,7 +169,7 @@ export function AuthModal({ open, onClose, redirectTo }: AuthModalProps) {
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="you@company.com"
                 onKeyDown={(e) => e.key === "Enter" && handleMagicLink()}
-                className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+                className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
               />
               <button
                 onClick={handleMagicLink}


### PR DESCRIPTION
## What changed
3 form inputs changed from `placeholder:text-muted-foreground` (full opacity) to `placeholder:text-muted-foreground/50`.

| File | Element | Count |
|------|---------|-------|
| `src/app/create/page.tsx` | Title input, Content textarea | 2 |
| `src/components/auth/AuthModal.tsx` | Email input | 1 |

## Why
Design system Text Input spec: `placeholder:text-muted-foreground/50`. Full-opacity placeholder text reduces visual contrast hierarchy — placeholder should be clearly subordinate to entered text.

## Rubric item
Off-rubric discovery. Design-system reference: Form Inputs → Text Input.

## Files modified
- `src/app/create/page.tsx`
- `src/components/auth/AuthModal.tsx`

## Tier
**Tier 0** — Token value normalization. No behavior change.

Note: PR #62 (open) fixes `focus:ring-accent` → `focus:ring-accent/50` in the same files. These changes are additive and will merge cleanly.