### PR TITLE
Add missing font-medium to label-pattern elements in card editor

### DIFF
--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -380,7 +380,7 @@ function EditableCardGrid({
           <div className="bg-white/5 rounded-lg p-4 border border-white/10 space-y-2">
             {/* Card style toggle */}
             <div className="flex items-center gap-2 mb-1">
-              <span className="text-[10px] text-muted-foreground uppercase tracking-wide">Style:</span>
+              <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Style:</span>
               {(["default", "quote"] as const).map((s) => (
                 <button
                   key={s}
@@ -422,7 +422,7 @@ function EditableCardGrid({
 
             {/* Tags editor */}
             <div className="pt-1">
-              <label className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">
+              <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide block mb-1">
                 Tags (comma-separated)
               </label>
               <input
@@ -443,7 +443,7 @@ function EditableCardGrid({
 
             {/* Metric editor */}
             <div className="pt-1">
-              <label className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">
+              <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide block mb-1">
                 Metric
               </label>
               <div className="flex gap-2">


### PR DESCRIPTION
## What changed
Added `font-medium` to 3 label-pattern elements in the ExpandableCards section editor.

| File | Element | Location |
|------|---------|----------|
| `EditableSectionRenderer.tsx` | Style toggle label `span` | line 383 |
| `EditableSectionRenderer.tsx` | Tags label `label` | line 425 |
| `EditableSectionRenderer.tsx` | Metric label `label` | line 446 |

## Why
Design system label pattern: `text-[10px] font-medium text-muted-foreground uppercase tracking-wide`. These 3 elements had the full pattern except `font-medium`. Without it, the label text renders at the default (normal) weight, which is visually inconsistent with other editor labels that correctly use `font-medium`.

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Label Pattern.

## Files modified
- `src/components/editor/EditableSectionRenderer.tsx`

## Tier
**Tier 0** — Token normalization. No behavior change.