### PR TITLE
Add missing font-medium to label-pattern spans in MultiSectionReview and TypeSelectorDropdown

### DIFF
--- a/src/components/editor/MultiSectionReview.tsx
+++ b/src/components/editor/MultiSectionReview.tsx
@@ -105,7 +105,7 @@ export function MultiSectionReview({
                 <p className="text-sm font-medium line-clamp-1">
                   {section.title}
                 </p>
-                <span className="text-[10px] text-accent/70 uppercase tracking-wide">
+                <span className="text-[10px] font-medium text-accent/70 uppercase tracking-wide">
                   {SECTION_TYPE_LABELS[section.type]}
                 </span>
                 {preview && (

--- a/src/components/editor/TypeSelectorDropdown.tsx
+++ b/src/components/editor/TypeSelectorDropdown.tsx
@@ -145,7 +145,7 @@ export function TypeSelectorDropdown({
       {isOpen && (
         <div className="absolute top-full left-0 mt-1 z-50 w-[240px] bg-background border border-white/10 rounded-lg shadow-xl overflow-hidden">
           <div className="px-3 py-2 border-b border-white/10">
-            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
               Change to...
             </span>
           </div>


### PR DESCRIPTION
## What changed
Added `font-medium` to 2 uppercase label spans missing it.

| File | Element | Context |
|------|---------|----------|
| `MultiSectionReview.tsx` | Section type badge `span` | Section type label below title in review list |
| `TypeSelectorDropdown.tsx` | "Change to..." header `span` | Dropdown column header |

## Why
Design system label pattern: `text-[10px] font-medium text-muted-foreground uppercase tracking-wide`. Both elements had `uppercase tracking-wide` (label voice) but were missing `font-medium`, causing them to render at default weight — inconsistent with other editor labels.

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Label Pattern.

## Files modified
- `src/components/editor/MultiSectionReview.tsx`
- `src/components/editor/TypeSelectorDropdown.tsx`

## Tier
**Tier 0** — Token normalization. No behavior change.