### PR TITLE
Normalize tracking-widest to tracking-wide in viewer components

### DIFF
--- a/src/components/viewer/ArtifactViewer.tsx
+++ b/src/components/viewer/ArtifactViewer.tsx
@@ -164,7 +164,7 @@ export function ArtifactViewer({
               >
                 {/* Beat label */}
                 <p
-                  className="mb-6 font-mono text-xs uppercase tracking-widest"
+                  className="mb-6 font-mono text-xs uppercase tracking-wide"
                   style={{ color: "var(--color-muted-foreground)" }}
                 >
                   Beat {beatNumber} / {totalBeats}

--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -440,7 +440,7 @@ function DetailPanel({
           }}
         >
           <div
-            className="mb-1 text-[10px] font-mono font-semibold uppercase tracking-widest"
+            className="mb-1 text-[10px] font-mono font-semibold uppercase tracking-wide"
             style={{ color }}
           >
             {event.trigger.label}


### PR DESCRIPTION
## What changed

Normalized `tracking-widest` to `tracking-wide` in two viewer components:
- `ArtifactViewer.tsx` line 167 — beat section label (font-mono uppercase)
- `GuidedJourney.tsx` line 443 — event trigger label (font-mono uppercase)

## Why

The design-system label pattern specifies `tracking-wide` as the only allowed value for uppercase metadata labels:
```
text-[10px] font-medium text-muted-foreground uppercase tracking-wide
```
`tracking-widest` is wider than the spec and inconsistent with the rest of the codebase. All other tracking-wider instances have been normalized to tracking-wide in PRs #72–74. These two remaining instances were missed because they use `font-mono` context.

## Rubric item

Discovery loop — extends the tracking normalization work from prior runs.

## Files modified
- `src/components/viewer/ArtifactViewer.tsx`
- `src/components/viewer/sections/GuidedJourney.tsx`

## Tier: 0
CSS token swap only. No layout or behavior change.