### PR TITLE
Normalize placeholder opacity to /50 in discover page inputs

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -161,7 +161,7 @@ export default function DiscoverPage() {
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="you@company.com"
                   required
-                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/40 focus:border-accent/50 focus:ring-1 focus:ring-accent/30 transition-colors"
+                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:border-accent/50 focus:ring-1 focus:ring-accent/30 transition-colors"
                 />
 
                 <select
@@ -184,7 +184,7 @@ export default function DiscoverPage() {
                   value={role}
                   onChange={(e) => setRole(e.target.value)}
                   placeholder="Your role (optional)"
-                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/40 focus:border-accent/50 focus:ring-1 focus:ring-accent/30 transition-colors"
+                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/50 focus:border-accent/50 focus:ring-1 focus:ring-accent/30 transition-colors"
                 />
 
                 <button


### PR DESCRIPTION
## What changed

Changed `placeholder:text-muted-foreground/40` to `placeholder:text-muted-foreground/50` in two form inputs on the waitlist page (`src/app/discover/page.tsx`):
- Email input (line 164)
- Role input (line 187)

## Why

The design-system specifies `placeholder:text-muted-foreground/50` as the standard placeholder opacity for all inputs. The `/40` value is off-spec and inconsistent with the rest of the codebase. The open PR #77 fixes this in `create/page.tsx` and `AuthModal.tsx`; this PR covers the missed instances in `discover/page.tsx`.

## Rubric item

Discovery loop — completes the placeholder opacity normalization sweep started in PR #77.

## Files modified
- `src/app/discover/page.tsx` (2 changes)

## Tier: 0
CSS token change only. No behavior change.