### PR TITLE
Add keyboard support and aria-expanded to expandable cards

### DIFF
--- a/src/components/viewer/sections/ExpandableCardGrid.tsx
+++ b/src/components/viewer/sections/ExpandableCardGrid.tsx
@@ -98,6 +98,9 @@ function Card({
       whileInView={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4, delay: index * 0.1 }}
       viewport={{ once: true, margin: "-50px" }}
+      role="button"
+      tabIndex={0}
+      aria-expanded={card.detail ? expanded : undefined}
       className={cn(
         "group cursor-pointer rounded-2xl border border-border bg-card p-6 transition-all duration-200",
         "hover:border-accent/30 hover:bg-card-hover",
@@ -105,6 +108,12 @@ function Card({
       )}
       style={borderStyle}
       onClick={() => setExpanded(!expanded)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          setExpanded(!expanded);
+        }
+      }}
     >
       {/* Header */}
       <div className="flex items-start justify-between">


### PR DESCRIPTION
## What changed

Added keyboard accessibility and ARIA semantics to expandable cards in `ExpandableCardGrid.tsx`:
- `role="button"` — identifies the div as interactive to assistive technology
- `tabIndex={0}` — makes cards focusable via Tab key
- `aria-expanded={expanded}` — announces open/closed state to screen readers (only when card has expandable detail)
- `onKeyDown` handler for Enter and Space — keyboard parity with mouse click

## Why

The expandable card was a `<motion.div>` with `onClick` but no keyboard support. Keyboard-only users and screen reader users could not interact with these cards. The design system states: "All interactive elements: focusable via Tab".

## Rubric item

Discovery loop — extends accessibility work from QR-14/QR-15. Applies to the viewer (investor-facing surface).

## Files modified
- `src/components/viewer/sections/ExpandableCardGrid.tsx`

## Tier: 1
Visual polish with keyboard behavior addition. No visual change for mouse users.