### PR TITLE
Rename unused prop interface params to _-prefix in AiChatPanel

### DIFF
--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -13,9 +13,9 @@ interface AiChatPanelProps {
   activeSectionId: string | null;
   activeSectionTitle: string | null;
   activeSectionType: SectionType | null;
-  onSend: (content: string) => void;
-  onApplySuggestion: (messageId: string) => void;
-  onDiscardSuggestion: (messageId: string) => void;
+  onSend: (_content: string) => void;
+  onApplySuggestion: (_messageId: string) => void;
+  onDiscardSuggestion: (_messageId: string) => void;
   onClearHistory: () => void;
 }
 


### PR DESCRIPTION
## What changed

Renamed 3 callback parameter names in the `AiChatPanelProps` interface to use the `_` prefix convention:
- `onSend: (content: string)` → `(_content: string)`
- `onApplySuggestion: (messageId: string)` → `(_messageId: string)`
- `onDiscardSuggestion: (messageId: string)` → `(_messageId: string)`

## Why

ESLint `no-unused-vars` was flagging these interface-level callback parameter names as unused. The rule requires unused params to match `/^_/u`. These are type-only annotations (the caller supplies the actual argument); naming them with `_` prefix satisfies the rule.

## Files modified
- `src/components/editor/AiChatPanel.tsx` (3 lines)

## Tier: 0
Type annotation rename only. Zero runtime behavior change.