### PR TITLE
Remove non-standard default ring from chart type select in EditableDataViz

### DIFF
--- a/src/components/editor/EditableDataViz.tsx
+++ b/src/components/editor/EditableDataViz.tsx
@@ -67,7 +67,7 @@ export function EditableDataViz({
           onChange={(e) =>
             onFieldChange("content.chart_type", e.target.value)
           }
-          className="bg-white/10 rounded px-2 py-1 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50"
+          className="bg-white/10 rounded px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-accent/50"
         >
           {CHART_TYPES.map((ct) => (
             <option key={ct.value} value={ct.value}>


### PR DESCRIPTION
## What changed
Removed `ring-1 ring-white/10` as a permanent (non-focus) ring from the chart type `<select>` in `EditableDataViz`.

Now uses only `focus:ring-1 focus:ring-accent/50` — the standard focus ring pattern from `docs/design-system.md`.

## Why
The design system specifies rings are focus indicators only. A default visible ring (`ring-1 ring-white/10`) is a decorative border, not a focus state, and violates the opacity system intent. Every other input and select in the codebase uses the focus-only ring pattern.

## Rubric item
Discovery — off-rubric. Conforms to: `docs/design-system.md` § Form Inputs, and the "Borders" section (`border-white/10` escalation rules).

## Files modified
- `src/components/editor/EditableDataViz.tsx` (1 line)

## Tier
**Tier 0** — Token-only change. No behavior change possible. Visual difference: the select no longer shows a subtle white ring at rest, only on focus.