### PR TITLE
Add font-medium to DocumentSettings toggle buttons

### DIFF
--- a/src/components/editor/DocumentSettings.tsx
+++ b/src/components/editor/DocumentSettings.tsx
@@ -130,7 +130,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
             <button
               key={mode}
               onClick={() => onUpdate("layout_mode", mode)}
-              className={`px-2.5 py-1 rounded text-xs transition-colors ${
+              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
                 (artifact.layout_mode ?? "continuous") === mode
                   ? "bg-accent/20 text-accent"
                   : "bg-white/10 text-muted-foreground hover:bg-white/20"
@@ -150,7 +150,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
             <button
               key={style}
               onClick={() => onUpdate("nav_style", style)}
-              className={`px-2.5 py-1 rounded text-xs transition-colors ${
+              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
                 (artifact.nav_style ?? "sidebar") === style
                   ? "bg-accent/20 text-accent"
                   : "bg-white/10 text-muted-foreground hover:bg-white/20"
@@ -170,7 +170,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
             <button
               key={theme}
               onClick={() => onUpdate("theme", theme)}
-              className={`px-2.5 py-1 rounded text-xs transition-colors ${
+              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
                 artifact.theme === theme
                   ? "bg-accent/20 text-accent"
                   : "bg-white/10 text-muted-foreground hover:bg-white/20"


### PR DESCRIPTION
## What changed
Added `font-medium` to the Layout mode, Navigation style, and Theme toggle buttons in `DocumentSettings.tsx`.

## Why
Design system small button pattern requires `px-2.5 py-1 rounded text-xs font-medium`. These 3 button groups had correct sizing/padding but were missing `font-medium`, making them visually lighter than spec.

## Design system reference
`docs/design-system.md` — Buttons > Button Sizing: `px-2.5 py-1 rounded text-xs font-medium // Small (inline actions)`

## Files modified
- `src/components/editor/DocumentSettings.tsx` (3 className changes)

## Rubric item
Discovery — not on rubric. Font-medium missing on buttons (separate from label font-medium fixes in PRs #78, #79, #84).

## Tier
**Tier 0** — token-only change. No behavior change possible.