### PR TITLE
Normalize text-[9px] to text-[10px] in GuidedJourney timeline event label

### DIFF
--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -347,7 +347,7 @@ function TimelineTrack({
                     </span>
                     <span
                       className={cn(
-                        "mt-0.5 max-w-[80px] text-center text-[9px] leading-tight transition-colors whitespace-nowrap",
+                        "mt-0.5 max-w-[80px] text-center text-[10px] leading-tight transition-colors whitespace-nowrap",
                         isActive
                           ? "font-semibold"
                           : "text-muted opacity-50"


### PR DESCRIPTION
## What changed

Normalized `text-[9px]` → `text-[10px]` in `GuidedJourney.tsx` timeline track event label span.

## Why

`text-[9px]` is on the design system kill list (see `docs/design-system.md` Typography section): "Kill list: `text-[11px]` (normalize to `text-xs`), `text-[9px]` (normalize to `text-[10px]`)".

## Rubric item

Discovery loop — off-rubric fix.

## Files modified

- `src/components/viewer/sections/GuidedJourney.tsx` (1 line)

## Tier

**Tier 0** — Token-only change. Text size token swap with no behavior change.

_Build: passing_