### PR TITLE
Normalize label pattern in EditableHubMockup Description field

### DIFF
--- a/src/components/editor/EditableHubMockup.tsx
+++ b/src/components/editor/EditableHubMockup.tsx
@@ -189,7 +189,7 @@ export function EditableHubMockup({
 
       {/* Description */}
       <div>
-        <label className="text-xs text-muted-foreground uppercase tracking-wider mb-1 block">
+        <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1 block">
           Description
         </label>
         <InlineEditor


### PR DESCRIPTION
## What changed

Fixed the "Description" form label in `EditableHubMockup.tsx` to match the design system label pattern.

**Before:** `text-xs text-muted-foreground uppercase tracking-wider`
**After:** `text-[10px] font-medium text-muted-foreground uppercase tracking-wide`

## Why

Three violations in one label:
1. `text-xs` (12px) — labels must be `text-[10px]`
2. Missing `font-medium` — required by label pattern
3. `tracking-wider` — design system specifies `tracking-wide`

Design system label pattern: `text-[10px] font-medium text-muted-foreground uppercase tracking-wide`

## Rubric item

Discovery loop — off-rubric fix.

## Files modified

- `src/components/editor/EditableHubMockup.tsx` (1 line)

## Tier

**Tier 0** — Token-only changes. Text size, weight, and tracking token swap. No behavior change.

_Build: passing_