### PR TITLE
Remove stale @next/next/no-img-element eslint-disable comments

### DIFF
--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -103,7 +103,6 @@ export function LogoUpload({
     return (
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-white/20 bg-white/5 p-1">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={logoUrl}
             alt="Logo preview"

--- a/src/components/viewer/SidebarNav.tsx
+++ b/src/components/viewer/SidebarNav.tsx
@@ -94,7 +94,6 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
         <div className="border-b border-border px-6 py-6">
           {logoUrl && (
             <div className="mb-3">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={logoUrl} alt="" className="h-8 w-auto object-contain" />
             </div>
           )}


### PR DESCRIPTION
## What changed
Removed two `eslint-disable-next-line @next/next/no-img-element` comments from:
- `src/components/viewer/SidebarNav.tsx:97`
- `src/components/editor/LogoUpload.tsx:106`

## Why
The `@next/next` ESLint plugin is not configured in `eslint.config.mjs` (the flat config). These disable comments referenced a non-existent rule, causing ESLint to emit:
```
error  Definition for rule '@next/next/no-img-element' was not found
```
Removing the comments eliminates the errors. The `<img>` elements remain valid — they use dynamic `src` values (logo URLs) that cannot use Next.js `<Image>` without a known `width`/`height`.

## Rubric item
Off-rubric discovery — not in `quality-rubric.md`.

## Files modified
- `src/components/viewer/SidebarNav.tsx`
- `src/components/editor/LogoUpload.tsx`

## Tier
**Tier 0** — Tokens only. Removing stale comments. No behavior change possible.