### PR TITLE
Normalize text-green-400 to text-success in AiChatPanel Applied indicator

### DIFF
--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -243,7 +243,7 @@ function MessageBubble({
         )}
 
         {message.suggestion && message.suggestion.status === "applied" && (
-          <p className="text-[10px] text-green-400 px-1 flex items-center gap-1">
+          <p className="text-[10px] text-success px-1 flex items-center gap-1">
             <Check className="w-3 h-3" />
             Applied
           </p>


### PR DESCRIPTION
## What changed
`text-green-400` on the "Applied" status badge in `AiChatPanel` replaced with `text-success`.

## Why
`text-green-400` resolves to `#4ade80` — but the design system defines `--color-success: #34d399` (emerald-400) in `globals.css` `@theme`. Using `text-success` binds to the semantic token rather than a raw Tailwind colour, keeping the Applied indicator consistent with any future palette updates.

## Rubric item
Discovery (off-rubric). CSS variable unification.

## Files modified
- `src/components/editor/AiChatPanel.tsx` — 1 line

## Tier
**Tier 0** — token-only change, no behavior or layout change.