### PR TITLE
Replace scrollSnapAlign inline style with snap-end utility in StrataFooter

### DIFF
--- a/src/components/viewer/StrataFooter.tsx
+++ b/src/components/viewer/StrataFooter.tsx
@@ -46,8 +46,7 @@ export function StrataFooter({ planTier = "free", isDemoPage = false }: StrataFo
 
   return (
     <footer
-      className="border-t border-border bg-footer-bg px-6 py-16 flex items-end"
-      style={{ scrollSnapAlign: "end" }}
+      className="border-t border-border bg-footer-bg px-6 py-16 flex items-end snap-end"
     >
       <div className="mx-auto flex max-w-4xl w-full items-center justify-between">
         <a


### PR DESCRIPTION
## What changed
Removed `style={{ scrollSnapAlign: "end" }}` from the beats-mode footer in `StrataFooter`. Replaced with Tailwind `snap-end` utility.

## Why
Inline style was equivalent to the standard Tailwind `snap-end` class (`scroll-snap-align: end`). Moving to className keeps all layout declarations in the class string and eliminates the unnecessary style object.

## Rubric item
Discovery (off-rubric). Inline style → Tailwind utility.

## Files modified
- `src/components/viewer/StrataFooter.tsx` — 1 line

## Tier
**Tier 0** — token-only change, no behavior or layout change.