### PR TITLE
Replace inline styles in ProgressBarNav share button with Tailwind utilities

### DIFF
--- a/src/components/viewer/ProgressBarNav.tsx
+++ b/src/components/viewer/ProgressBarNav.tsx
@@ -158,10 +158,7 @@ export function ProgressBarNav({
       </div>
 
       {/* Share button — fixed top-right, below the progress bar */}
-      <div
-        className="fixed z-50"
-        style={{ top: "10px", right: "16px" }}
-      >
+      <div className="fixed top-2.5 right-4 z-50">
         <button
           onClick={async () => {
             try {
@@ -181,23 +178,11 @@ export function ProgressBarNav({
           aria-label="Copy link to clipboard"
         >
           {copied ? (
-            <span
-              style={{
-                fontSize: "11px",
-                color: "var(--color-success, #22c55e)",
-                fontWeight: 500,
-              }}
-            >
+            <span className="text-xs font-medium text-success">
               Copied!
             </span>
           ) : (
-            <Share2
-              style={{
-                width: "14px",
-                height: "14px",
-                color: "var(--color-muted-foreground)",
-              }}
-            />
+            <Share2 className="w-3.5 h-3.5 text-muted-foreground" />
           )}
         </button>
       </div>


### PR DESCRIPTION
## What changed
Share button section in `ProgressBarNav` had several inline style objects replaced with Tailwind utilities:

- **Container position** — `style={{ top: "10px", right: "16px" }}` → `top-2.5 right-4`
- **"Copied!" text** — `fontSize: "11px"` → `text-xs` (kill list: 11px normalises to 12px/text-xs), `color: "var(--color-success, #22c55e)"` → `text-success`, `fontWeight: 500` → `font-medium`
- **Share2 icon** — `style={{ width: "14px", height: "14px", color: "var(--color-muted-foreground)" }}` → `className="w-3.5 h-3.5 text-muted-foreground"`

## Why
All three were simple inline-style-to-Tailwind conversions. No equivalent Tailwind class was being used despite one existing. The `11px` font size also hits the design-system kill list; normalised to `text-xs` (12px). The success colour now uses the semantic `text-success` token rather than a fallback CSS variable string.

## Rubric item
Discovery (off-rubric). Inline style elimination + kill-list text size + CSS variable unification.

## Files modified
- `src/components/viewer/ProgressBarNav.tsx` — share button block (lines 160-203)

## Tier
**Tier 0** — token and class unification only, no behaviour or layout change.