### PR TITLE
Remove unused React default import from SectionPreviewPanel.tsx

### DIFF
--- a/src/components/editor/SectionPreviewPanel.tsx
+++ b/src/components/editor/SectionPreviewPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { memo, useRef, useEffect } from "react";
+import { memo, useRef, useEffect } from "react";
 import type { Section, Artifact } from "@/types/artifact";
 import { SectionRenderer } from "@/components/viewer/SectionRenderer";
 import { Maximize2, Minimize2 } from "lucide-react";


### PR DESCRIPTION
## What changed

Removed the unused `React` default import from `SectionPreviewPanel.tsx`.

```diff
- import React, { memo, useRef, useEffect } from "react";
+ import { memo, useRef, useEffect } from "react";
```

## Why

`React` (the default export) is not referenced anywhere in this file. The component uses `memo`, `useRef`, and `useEffect` by name — no `React.` prefix is used anywhere. With the new JSX transform (React 17+), the default import is never needed for JSX rendering either.

ESLint would flag this as `no-unused-vars`.

## Rubric item

Discovery loop — off-rubric fix (not covered by any existing open PR).

## Files modified

- `src/components/editor/SectionPreviewPanel.tsx`

## Tier

**Tier 0** — Token-only change. Removes an unused import. Zero behavior change.