### PR TITLE
Replace inline success color with text-success class in TierTable ComparisonColumn

### DIFF
--- a/src/components/viewer/sections/TierTable.tsx
+++ b/src/components/viewer/sections/TierTable.tsx
@@ -54,8 +54,7 @@ function ComparisonColumn({
               <li key={feature.name} className="flex items-start gap-3 text-sm">
                 {included ? (
                   <Check
-                    className="mt-0.5 h-4 w-4 shrink-0"
-                    style={{ color: "var(--color-success, #10b981)" }}
+                    className="mt-0.5 h-4 w-4 shrink-0 text-success"
                   />
                 ) : (
                   <X


### PR DESCRIPTION
## What changed

In `TierTable.tsx`, the `ComparisonColumn` component was using an inline style for the Check icon color:

```diff
- <Check
-   className="mt-0.5 h-4 w-4 shrink-0"
-   style={{ color: "var(--color-success, #10b981)" }}
- />
+ <Check
+   className="mt-0.5 h-4 w-4 shrink-0 text-success"
+ />
```

## Why

The `text-success` utility class already exists (via `--color-success` in `@theme`) and is the correct pattern. The `PricingColumn` section at the bottom of the same file already uses `className="... text-success"` for its Check icon — this brings `ComparisonColumn` into alignment.

Bonus: removes the wrong fallback hex (`#10b981`) — design-system defines `--color-success` as `#34d399`.

## Rubric item

Discovery loop — off-rubric fix. Design-system reference: use utility classes for named semantic color tokens instead of inline CSS variable expressions.

## Files modified

- `src/components/viewer/sections/TierTable.tsx`

## Tier

**Tier 0** — Token-only change. Replaces inline style with utility class. Zero behavior change (same CSS variable, same rendered color).