### PR TITLE
Normalize hover:text-red-400 to hover:text-danger in editor components

### DIFF
--- a/src/components/editor/AddSectionPaste.tsx
+++ b/src/components/editor/AddSectionPaste.tsx
@@ -137,7 +137,7 @@ export function AddSectionPaste({
         <div className="flex items-center justify-between">
           <span
             className={`text-[10px] ${
-              overLimit ? "text-red-400" : "text-muted-foreground"
+              overLimit ? "text-danger" : "text-muted-foreground"
             }`}
           >
             {charCount.toLocaleString()} / {MAX_CHARS.toLocaleString()} chars

--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -216,7 +216,7 @@ function SectionImagePreview({
         )}
         <button
           onClick={() => onFieldChange("image_url", undefined)}
-          className="flex items-center gap-1 px-2 py-1.5 rounded-md text-xs text-muted-foreground hover:text-red-400 transition-colors ml-auto"
+          className="flex items-center gap-1 px-2 py-1.5 rounded-md text-xs text-muted-foreground hover:text-danger transition-colors ml-auto"
         >
           <XIcon className="w-3 h-3" />
           Remove image
@@ -496,7 +496,7 @@ function EditableCardGrid({
               ))}
               <button
                 onClick={() => onFieldChange("content.callout", undefined)}
-                className="ml-auto text-xs text-muted-foreground hover:text-red-400 transition-colors"
+                className="ml-auto text-xs text-muted-foreground hover:text-danger transition-colors"
               >
                 Remove
               </button>
@@ -784,7 +784,7 @@ function EditableTierTable({
                 </span>
                 <button
                   onClick={() => handleRemoveFeature(i, j)}
-                  className="opacity-0 group-hover/feat:opacity-50 hover:!opacity-100 hover:text-red-400 transition-opacity text-xs"
+                  className="opacity-0 group-hover/feat:opacity-50 hover:!opacity-100 hover:text-danger transition-opacity text-xs"
                 >
                   ×
                 </button>

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -597,7 +597,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
             <div className="sticky top-0 z-20 mx-auto max-w-4xl px-6 pt-3">
               <div className="flex items-center gap-2 rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-2.5 text-sm text-red-400">
                 <span className="flex-1">{imageError}</span>
-                <button onClick={() => setImageError(null)} className="text-red-400/60 hover:text-red-400 transition-colors">
+                <button onClick={() => setImageError(null)} className="text-danger/60 hover:text-danger transition-colors">
                   <XIcon className="w-4 h-4" />
                 </button>
               </div>

--- a/src/components/editor/ItemManager.tsx
+++ b/src/components/editor/ItemManager.tsx
@@ -69,7 +69,7 @@ function SortableRow({
       {canRemove && (
         <button
           onClick={onRemove}
-          className="mt-3 opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400 transition-opacity shrink-0"
+          className="mt-3 opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-danger transition-opacity shrink-0"
           tabIndex={-1}
         >
           <Trash2 className="w-3.5 h-3.5" />

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -154,7 +154,7 @@ function SortableItem({
         className={`flex items-center gap-1 rounded px-1.5 py-0.5 transition-all ${
           confirmDelete
             ? "opacity-100 bg-red-500/10 text-red-400 border border-red-500/20"
-            : "opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400 border border-transparent"
+            : "opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-danger border border-transparent"
         }`}
       >
         <Trash2 className="w-3.5 h-3.5 shrink-0" />


### PR DESCRIPTION
## What changed

Replaced 7 raw Tailwind color usages (`text-red-400`, `hover:text-red-400`) with the design-system semantic token `text-danger` / `hover:text-danger` across 5 editor files.

## Files modified

| File | Change |
|------|--------|
| `SortableSectionList.tsx` | Delete button idle hover: `hover:text-red-400` → `hover:text-danger` |
| `EditorLayout.tsx` | Image error dismiss X: `text-red-400/60 hover:text-red-400` → `text-danger/60 hover:text-danger` |
| `EditableSectionRenderer.tsx` | 3 instances — remove image, remove callout, remove tier feature |
| `ItemManager.tsx` | Row trash button hover |
| `AddSectionPaste.tsx` | Over-limit character count indicator |

## Why

Design system rule: "All colors come from CSS variables in `globals.css`. Never use raw hex in components." The same principle applies to raw Tailwind palette utilities — use the semantic token (`text-danger`) instead of the equivalent raw class (`text-red-400`).

`--color-danger: #f87171` = Tailwind `red-400`. No visual change.

## What was NOT changed

Error pill instances (`bg-red-500/10 text-red-400 border border-red-500/20`) were left unchanged — that exact pattern is specified in `design-system.md` as the QR-03 standard error pattern and uses `red-500` for background/border which has no equivalent CSS variable token.

## Rubric item

Discovery loop — off-rubric fix. Design-system reference: semantic color token normalization.

## Tier

**Tier 0** — Token-only change. No behavior or visual change.