### PR TITLE
Add aria-expanded to RichTextCollapsible expand/collapse button

### DIFF
--- a/src/components/viewer/sections/RichTextCollapsible.tsx
+++ b/src/components/viewer/sections/RichTextCollapsible.tsx
@@ -93,6 +93,7 @@ export function RichTextCollapsible({
         <>
           <button
             onClick={() => setExpanded(!expanded)}
+            aria-expanded={expanded}
             className="mt-6 flex items-center gap-2 text-sm font-medium text-accent hover:text-accent-hover transition-colors"
           >
             <ChevronDown


### PR DESCRIPTION
## What changed

Added `aria-expanded={expanded}` to the "Read more" / "Show less" button in `RichTextCollapsible.tsx`.

```diff
 <button
   onClick={() => setExpanded(!expanded)}
+  aria-expanded={expanded}
   className="mt-6 flex items-center gap-2 ..."
>
```

## Why

This button controls a collapsible detail section. The `aria-expanded` attribute signals to assistive technology whether the controlled content is currently shown (`true`) or hidden (`false`). Without it, screen readers announce the button but cannot communicate whether the section is open or closed — only the visible text "Read more" / "Show less" provides that signal.

This is a standard ARIA 1.1 pattern for disclosure widgets (the expand button directly controls the visible content region).

## Rubric item

Discovery loop — off-rubric fix. Design-system reference: accessibility minimum for dynamic disclosure widgets. Not covered by PR #85 (which targets `ExpandableCardGrid`) or PR #6 (which targets `aria-live` regions).

## Files modified

- `src/components/viewer/sections/RichTextCollapsible.tsx`

## Tier

**Tier 0** — Token-only change. Adds a semantic ARIA attribute. Zero behavior change.