### PR TITLE
Normalize off-palette blue badge tokens to design-system tokens in EditableSectionRenderer

### DIFF
--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -60,7 +60,7 @@ export function EditableSectionRenderer({
           {SECTION_TYPE_LABELS[section.type]}
         </span>
         {section.image_url && (
-          <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium tracking-wide uppercase bg-blue-500/10 text-blue-400/80 border border-blue-500/20">
+          <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium tracking-wide uppercase bg-white/5 text-muted-foreground border border-white/10">
             <ImageIcon className="w-3 h-3" />
             Image
           </span>


### PR DESCRIPTION
## What changed
Replaced `bg-blue-500/10 text-blue-400/80 border border-blue-500/20` on the "Image" badge in `EditableSectionRenderer.tsx` with design-system tokens: `bg-white/5 text-muted-foreground border border-white/10`.

## Why
The Image badge was using raw Tailwind blue color classes not in the Strata design system palette. The design system defines only: accent (indigo), success (green), warning (amber), danger (red), and white-opacity variants. Blue is not part of the palette. The sibling section-type badge correctly uses `bg-accent/10 text-accent/80 border border-accent/20`.

## Rubric item
Off-rubric discovery: raw off-palette Tailwind color in editor component badge.

## Files modified
- `src/components/editor/EditableSectionRenderer.tsx` (line 63)

## Tier
Tier 0 — CSS token-only change. No behavior change possible.