### PR TITLE
Normalize focus ring opacity to accent/50 in discover page inputs

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -161,13 +161,13 @@ export default function DiscoverPage() {
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="you@company.com"
                   required
-                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/40 focus:border-accent/50 focus:ring-1 focus:ring-accent/30 transition-colors"
+                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/40 focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-colors"
                 />
 
                 <select
                   value={useCase}
                   onChange={(e) => setUseCase(e.target.value)}
-                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none text-muted-foreground focus:border-accent/50 focus:ring-1 focus:ring-accent/30 transition-colors appearance-none"
+                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none text-muted-foreground focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-colors appearance-none"
                 >
                   <option value="">What would you build? (optional)</option>
                   <option value="investor-deck">Investor deck</option>
@@ -184,7 +184,7 @@ export default function DiscoverPage() {
                   value={role}
                   onChange={(e) => setRole(e.target.value)}
                   placeholder="Your role (optional)"
-                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/40 focus:border-accent/50 focus:ring-1 focus:ring-accent/30 transition-colors"
+                  className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm outline-none placeholder:text-muted-foreground/40 focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-colors"
                 />
 
                 <button


### PR DESCRIPTION
## What changed
Three form inputs in `src/app/discover/page.tsx` (email, use-case select, role) used `focus:ring-accent/30` instead of the design-system standard `focus:ring-accent/50`.

## Why
Design system Form Inputs spec defines `focus:ring-1 focus:ring-accent/50` as the only allowed focus ring pattern. `/30` is off-spec and inconsistent with `create/page.tsx` and `AuthModal.tsx` (already fixed in `disc-normalize-focus-ring-opacity`).

## Rubric item
Off-rubric discovery — same pattern as existing PR `disc-normalize-focus-ring-opacity`.

## Files modified
- `src/app/discover/page.tsx` (3 lines)

## Tier
**Tier 0** — token-only change. No behavior change possible.