### PR TITLE
Remove non-standard default ring from chart type select in EditableDataViz

### DIFF
--- a/src/components/editor/EditableDataViz.tsx
+++ b/src/components/editor/EditableDataViz.tsx
@@ -67,7 +67,7 @@ export function EditableDataViz({
           onChange={(e) =>
             onFieldChange("content.chart_type", e.target.value)
           }
-          className="bg-white/10 rounded px-2 py-1 text-sm outline-none ring-1 ring-white/10 focus:ring-accent/50"
+          className="bg-white/10 rounded px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-accent/50"
         >
           {CHART_TYPES.map((ct) => (
             <option key={ct.value} value={ct.value}>


### PR DESCRIPTION
## What changed
Removed `ring-1 ring-white/10` from the always-visible (default) state of the chart type `<select>` in `EditableDataViz.tsx`. Ring now only appears on focus (`focus:ring-1 focus:ring-accent/50`).

## Why
Design system Form Inputs: `outline-none focus:ring-1 focus:ring-accent/50` — no default ring. `ring-white/10` applied unconditionally creates a visible default ring that is off-spec. This is the same pattern already fixed in `EditableGuidedJourney` and `EditableHubMockup` via `disc-normalize-inline-edit-ring`, which missed this select element in `EditableDataViz`.

## Rubric item
Off-rubric discovery. Same pattern as `disc-normalize-inline-edit-ring`.

## Files modified
- `src/components/editor/EditableDataViz.tsx` (1 line)

## Tier
**Tier 0** — token-only change. No behavior change possible.