### PR TITLE
Normalize tracking-widest to tracking-wide in not-found.tsx brand label

### DIFF
--- a/src/app/[slug]/not-found.tsx
+++ b/src/app/[slug]/not-found.tsx
@@ -4,7 +4,7 @@ export default function ArtifactNotFound() {
   return (
     <div className="min-h-screen bg-[#0a0b10] flex items-center justify-center px-6">
       <div className="text-center max-w-sm">
-        <p className="text-[10px] font-medium text-[#6366f1]/60 uppercase tracking-widest mb-6">
+        <p className="text-[10px] font-medium text-[#6366f1]/60 uppercase tracking-wide mb-6">
           Strata
         </p>
         <h1 className="text-2xl font-bold text-[#e8eaf0] mb-3">


### PR DESCRIPTION
## What changed
Changed `tracking-widest` to `tracking-wide` on the "Strata" brand label in `src/app/[slug]/not-found.tsx`.

## Why
Design system Label Pattern specifies `tracking-wide` as the standard for uppercase metadata labels. `tracking-widest` is off-spec. The existing open PR `disc-not-found-css-vars` fixes the raw hex color on the same line but does not touch the tracking value — these two fixes are orthogonal and can merge in either order.

`disc-normalize-tracking-widest-viewer` (open) fixed the same issue in `ArtifactViewer.tsx` and `GuidedJourney.tsx` but did not include `not-found.tsx`.

## Rubric item
Off-rubric discovery. Design-system reference: Typography → Label Pattern.

## Files modified
- `src/app/[slug]/not-found.tsx` (1 line)

## Tier
**Tier 0** — token-only change. No behavior change possible.