### PR TITLE
Add aria-label to image error dismiss button in EditorLayout

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -597,7 +597,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
             <div className="sticky top-0 z-20 mx-auto max-w-4xl px-6 pt-3">
               <div className="flex items-center gap-2 rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-2.5 text-sm text-red-400">
                 <span className="flex-1">{imageError}</span>
-                <button onClick={() => setImageError(null)} className="text-red-400/60 hover:text-red-400 transition-colors">
+                <button onClick={() => setImageError(null)} aria-label="Dismiss image error" className="text-red-400/60 hover:text-red-400 transition-colors">
                   <XIcon className="w-4 h-4" />
                 </button>
               </div>


### PR DESCRIPTION
## What changed
Added `aria-label="Dismiss image error"` to the XIcon button that dismisses the image upload error toast in `EditorLayout.tsx`.

## Why
This icon-only button had no accessible label — screen readers would announce it as an unnamed interactive element. QR-15 (PR #7) added `aria-label` to icon-only buttons in SortableSectionList, ItemManager, AiChatPanel, SplitViewLayout, and MobilePreviewSheet, but missed this button in EditorLayout.

## Rubric item
Off-rubric discovery. Related to QR-15 (ARIA labels on icon-only buttons).

## Files modified
- `src/components/editor/EditorLayout.tsx` (1 line)

## Tier
**Tier 0** — attribute-only change. No behavior or visual change.