### PR TITLE
Normalize hover:border-white/40 to hover:border-white/30 in upload zone buttons

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -529,7 +529,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                     <div className="p-2 border-t border-white/10 space-y-2">
                       <button
                         onClick={() => setShowAddSection(true)}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/30 hover:text-foreground transition-colors"
                       >
                         <Plus className="w-4 h-4" />
                         Add Section
@@ -537,7 +537,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                       <button
                         onClick={() => fileInputRef.current?.click()}
                         disabled={isProcessingImage}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/30 hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <ImageIcon className="w-4 h-4" />
                         {isProcessingImage ? "Processing..." : "Add from Image"}

--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -138,7 +138,7 @@ export function LogoUpload({
         className={`flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-4 text-xs transition-colors ${
           dragOver
             ? "border-accent/60 bg-accent/10 text-accent"
-            : "border-white/20 bg-white/5 text-muted-foreground hover:border-white/40 hover:bg-white/10 hover:text-foreground"
+            : "border-white/20 bg-white/5 text-muted-foreground hover:border-white/30 hover:bg-white/10 hover:text-foreground"
         } ${uploading ? "pointer-events-none opacity-50" : ""}`}
       >
         {uploading ? (

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -322,7 +322,7 @@ export function SplitViewLayout({
                     <div className="p-2 border-t border-white/10 space-y-2">
                       <button
                         onClick={() => setShowAddSection(true)}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/30 hover:text-foreground transition-colors"
                       >
                         <Plus className="w-4 h-4" />
                         Add Section
@@ -333,7 +333,7 @@ export function SplitViewLayout({
                           handleCloseSidebarOverlay();
                         }}
                         disabled={isProcessingImage}
-                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/40 hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-dashed border-white/20 text-sm text-muted-foreground hover:border-white/30 hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <ImageIcon className="w-4 h-4" />
                         {isProcessingImage ? "Processing..." : "Add from Image"}


### PR DESCRIPTION
## What changed
5 upload zone dashed-border buttons were using `hover:border-white/40` — above the design system ceiling.

## Why
Design system defines `border-white/30` as the maximum for deep hover on interactive bordered elements (upload zones, interactive borders). `/40` is non-standard.

## Rubric item
Off-rubric — discovered during opacity normalization sweep.

## Files modified
- `src/components/editor/SplitViewLayout.tsx` — 2 buttons (Add Section, Add from Image)
- `src/components/editor/EditorLayout.tsx` — 2 buttons (same pattern)
- `src/components/editor/LogoUpload.tsx` — 1 drop zone

## Tier
**Tier 0** — token-only change, no behavior change possible.