### PR TITLE
Normalize p-5 to p-4 in keyboard shortcuts overlay

### DIFF
--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -390,7 +390,7 @@ export function SplitViewLayout({
               transition={{ duration: 0.15 }}
               className="absolute inset-0 flex items-center justify-center z-50 pointer-events-none"
             >
-              <div className="bg-surface border border-white/10 rounded-xl shadow-2xl w-80 p-5 pointer-events-auto">
+              <div className="bg-surface border border-white/10 rounded-xl shadow-2xl w-80 p-4 pointer-events-auto">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2">
                     <Keyboard className="w-4 h-4 text-accent" />


### PR DESCRIPTION
## What changed
Keyboard shortcuts overlay container was using `p-5` — not in the standard spacing scale.

## Why
Design system standard padding for panel content is `p-3` or `p-4`. The keyboard shortcuts overlay is a compact card (w-80, 5 shortcut rows), so `p-4` is the correct size.

## Rubric item
Off-rubric — discovered during spacing normalization sweep.

## Files modified
- `src/components/editor/SplitViewLayout.tsx` — keyboard shortcuts overlay container (1 instance)

## Tier
**Tier 0** — token-only spacing change, no behavior change possible.