### PR TITLE
Remove dead container variable in ArtifactViewer keyboard handler

### DIFF
--- a/src/components/viewer/ArtifactViewer.tsx
+++ b/src/components/viewer/ArtifactViewer.tsx
@@ -83,8 +83,6 @@ export function ArtifactViewer({
       }
     };
 
-    // Attach to the scroll container if available, otherwise window
-    const container = scrollContainerRef.current ?? window;
     // scrollIntoView works relative to the viewport, so window keydown is fine
     window.addEventListener("keydown", handleKeyDown);
     return () => {


### PR DESCRIPTION
## What changed

Removed the unused `container` variable on line 87 of `ArtifactViewer.tsx`.

The code assigned `scrollContainerRef.current ?? window` to `container` but then attached the event listener to `window` directly on the very next line. The existing comment already explained why: "scrollIntoView works relative to the viewport, so window keydown is fine." The assignment was dead code and triggered an ESLint `no-unused-vars` warning.

## Why

Dead variable removal. No behavior change — the listener was always attached to `window`, not `container`.

## Rubric item

Discovery (off-rubric lint fix — not in any open PR)

## Files modified

- `src/components/viewer/ArtifactViewer.tsx` (2 lines removed)

## Tier

**Tier 0** — Token/lint-only change. Dead variable removal, no behavior change possible.