### PR TITLE
Rename onSelect callback param from index to _index in TimelineTrack

### DIFF
--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -214,7 +214,7 @@ function TimelineTrack({
   phases: JourneyPhase[];
   activeIndex: number;
   visited: Set<number>;
-  onSelect: (index: number) => void;
+  onSelect: (_index: number) => void;
 }) {
   const trackRef = useRef<HTMLDivElement>(null);
   const hasMounted = useRef(false);


### PR DESCRIPTION
## What changed

Renamed the `index` parameter to `_index` in the `TimelineTrack` component prop type in `GuidedJourney.tsx` (line 217).

```tsx
// Before
onSelect: (index: number) => void;

// After
onSelect: (_index: number) => void;
```

## Why

ESLint `no-unused-vars` flags named parameters in function type annotations when the name is not referenced at the declaration site. This is a false-positive characteristic of the rule for TypeScript callback signatures, but the project convention (see other open PRs) is to prefix unused parameter names with `_` to silence the warning.

No behavior change — this is purely a type-annotation rename.

## Rubric item

Discovery (off-rubric lint fix — not covered by any open PR)

## Files modified

- `src/components/viewer/sections/GuidedJourney.tsx` (1 line changed)

## Tier

**Tier 0** — Parameter rename in type annotation only. No behavior change possible.