### PR TITLE
Add aria-expanded to CollapsiblePanel toggle button in EditableGuidedJourney

### DIFF
--- a/src/components/editor/EditableGuidedJourney.tsx
+++ b/src/components/editor/EditableGuidedJourney.tsx
@@ -77,6 +77,7 @@ function CollapsiblePanel({
     <div className="border border-white/10 rounded-lg overflow-hidden">
       <button
         onClick={onToggle}
+        aria-expanded={isOpen}
         className="w-full flex items-center gap-2 px-4 py-2.5 bg-white/5 hover:bg-white/10 transition-colors text-sm font-medium"
       >
         {isOpen ? (


### PR DESCRIPTION
## What changed

Added `aria-expanded={isOpen}` to the `CollapsiblePanel` toggle button in `EditableGuidedJourney.tsx`.

The component renders three collapsible sections (Phases, Events, Metrics). The toggle button already had a visual chevron indicator (ChevronDown / ChevronRight), but no `aria-expanded` attribute for screen readers to announce the open/closed state.

## Why

Design system accessibility minimum: "Dynamic status changes: `aria-live="polite"`". Per WCAG 4.1.2, disclosure buttons must communicate their expanded state via `aria-expanded`. Without it, screen reader users cannot tell whether the panel is open or closed before activating the button.

No open PR covers this component — QR-15 (icon buttons) and PR #106 (RichTextCollapsible) both target different components.

## Rubric item

Discovery (off-rubric accessibility fix — not covered by any open PR)

## Files modified

- `src/components/editor/EditableGuidedJourney.tsx` (1 line added)

## Tier

**Tier 0** — ARIA attribute addition. No visual or behavior change.