### PR TITLE
Add aria-expanded to TypeSelectorDropdown trigger button

### DIFF
--- a/src/components/editor/TypeSelectorDropdown.tsx
+++ b/src/components/editor/TypeSelectorDropdown.tsx
@@ -119,6 +119,7 @@ export function TypeSelectorDropdown({
       <button
         onClick={() => !isLoading && setIsOpen((v) => !v)}
         disabled={isLoading}
+        aria-expanded={isOpen}
         className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {isLoading ? (


### PR DESCRIPTION
## What changed

Added `aria-expanded={isOpen}` to the dropdown trigger button in `TypeSelectorDropdown.tsx`.

## Why

The type-selector button opens/closes a dropdown listing available section types. Screen readers need `aria-expanded` to announce the open/closed state before the user activates the button. Without it, the state change is silent to assistive technology.

PR #19 (QR-13 error-persist) and PR #47 (unused imports) both touched this file but neither added `aria-expanded`.

## Rubric item

Discovery (off-rubric accessibility fix — not covered by any open PR)

## Files modified

- `src/components/editor/TypeSelectorDropdown.tsx` (1 line added)

## Tier

**Tier 0** — ARIA attribute addition. No visual or behavior change.