### PR TITLE
Add aria-expanded to mobile navigation toggle in SidebarNav

### DIFF
--- a/src/components/viewer/SidebarNav.tsx
+++ b/src/components/viewer/SidebarNav.tsx
@@ -70,6 +70,7 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
         onClick={() => setMobileOpen(!mobileOpen)}
         className="fixed top-4 left-4 z-50 rounded-lg bg-card p-2 shadow-lg lg:hidden"
         aria-label="Toggle navigation"
+        aria-expanded={mobileOpen}
       >
         {mobileOpen ? (
           <X className="h-5 w-5 text-foreground" />


### PR DESCRIPTION
## What changed

Added `aria-expanded={mobileOpen}` to the mobile hamburger button in `SidebarNav.tsx`.

## Why

The button already had `aria-label="Toggle navigation"` to identify its purpose, but without `aria-expanded`, screen readers cannot announce whether the sidebar drawer is currently open or closed. Per WCAG 4.1.2, disclosure widgets must communicate state via `aria-expanded`.

No open PR covers the SidebarNav mobile toggle — QR-15 and related aria PRs target editor icon buttons.

## Rubric item

Discovery (off-rubric accessibility fix — not covered by any open PR)

## Files modified

- `src/components/viewer/SidebarNav.tsx` (1 line added)

## Tier

**Tier 0** — ARIA attribute addition. No visual or behavior change.