### PR TITLE
Remove debug console.log calls from updateArtifact in actions.ts

### DIFF
--- a/src/lib/artifacts/actions.ts
+++ b/src/lib/artifacts/actions.ts
@@ -100,7 +100,6 @@ export async function updateArtifact(
     }
   }
 
-  console.log("[updateArtifact] saving slug:", slug, "title:", input.title, "sectionCount:", input.sections?.length);
   const { error } = await getSupabase()
     .from("artifacts")
     .update({ ...input, updated_at: new Date().toISOString() })
@@ -111,7 +110,6 @@ export async function updateArtifact(
     return { error: error.message };
   }
 
-  console.log("[updateArtifact] SUCCESS for slug:", slug);
   return { success: true };
 }
 


### PR DESCRIPTION
## What changed

Removed two `console.log` calls from the `updateArtifact` function in `src/lib/artifacts/actions.ts`:

- Line 103: `"[updateArtifact] saving slug:"` — pre-save status log
- Line 114: `"[updateArtifact] SUCCESS for slug:"` — post-save confirmation log

The `console.error` on the failure path is preserved.

## Why

These are development debug logs, not error handling. Same pattern as PR #40 which removed the debug `console.log` from `discover/page.tsx`. Production builds should not emit `console.log` output for successful operations.

## Rubric item

Discovery (off-rubric debug cleanup — not covered by any open PR)

## Files modified

- `src/lib/artifacts/actions.ts` (2 lines removed)

## Tier

**Tier 0** — Debug log removal. No behavior change.