### PR TITLE
Add aria-pressed to publish toggle button in TopBar

### DIFF
--- a/src/components/editor/TopBar.tsx
+++ b/src/components/editor/TopBar.tsx
@@ -56,6 +56,7 @@ export function TopBar({
       {/* Publish toggle */}
       <button
         onClick={onPublishToggle}
+        aria-pressed={isPublished}
         className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
           isPublished
             ? "bg-green-600/20 text-green-400 hover:bg-green-600/30"


### PR DESCRIPTION
## What changed

Added aria-pressed to the publish/draft toggle in TopBar.tsx.

## Why

The button switches between Published and Draft states. aria-pressed lets screen readers announce the current toggle state programmatically. No open PR covers this — PR #6 adds aria-live to save status but not to the publish toggle.

## Files modified

- src/components/editor/TopBar.tsx (1 line added)

## Tier

Tier 0 — ARIA attribute addition. No visual or behavior change.