### PR TITLE
Add aria-pressed to DocumentSettings toggle button groups

### DIFF
--- a/src/components/editor/DocumentSettings.tsx
+++ b/src/components/editor/DocumentSettings.tsx
@@ -130,6 +130,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
             <button
               key={mode}
               onClick={() => onUpdate("layout_mode", mode)}
+              aria-pressed={(artifact.layout_mode ?? "continuous") === mode}
               className={`px-2.5 py-1 rounded text-xs transition-colors ${
                 (artifact.layout_mode ?? "continuous") === mode
                   ? "bg-accent/20 text-accent"
@@ -150,6 +151,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
             <button
               key={style}
               onClick={() => onUpdate("nav_style", style)}
+              aria-pressed={(artifact.nav_style ?? "sidebar") === style}
               className={`px-2.5 py-1 rounded text-xs transition-colors ${
                 (artifact.nav_style ?? "sidebar") === style
                   ? "bg-accent/20 text-accent"
@@ -170,6 +172,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
             <button
               key={theme}
               onClick={() => onUpdate("theme", theme)}
+              aria-pressed={artifact.theme === theme}
               className={`px-2.5 py-1 rounded text-xs transition-colors ${
                 artifact.theme === theme
                   ? "bg-accent/20 text-accent"


### PR DESCRIPTION
Adds aria-pressed to the Layout (continuous/beats), Navigation (sidebar/progress-bar), and Theme (dark/light) toggle buttons in DocumentSettings.tsx. Screen readers now announce checked/unchecked state for all 6 toggle buttons.

Tier: 0 (accessibility attribute, no visual change)
Files: src/components/editor/DocumentSettings.tsx