### PR TITLE
Add loading skeleton to artifact page — no blank flash on hard-refresh (QR-17)

### DIFF
--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -109,12 +109,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 
 ## Priority 5: Viewer Quality (investor-facing surface)
 
-### QR-17: Add loading skeleton to artifact page
-- **Tier:** 1
-- **What:** Show a content skeleton (pulsing gray blocks for title, subtitle, and section placeholders) while Supabase fetch completes. Currently the page is blank for 1-2 seconds.
-- **Files:** `src/app/[slug]/page.tsx` or the viewer layout component
-- **Test:** Hard-refresh an artifact page — see skeleton animation, then smooth transition to content (no blank flash)
-- **Status:** OPEN
+### ~~QR-17: Add loading skeleton to artifact page~~ DONE
+- **Status:** DONE — PR created 2026-04-05. Created `src/app/[slug]/loading.tsx` — Next.js App Router loading.tsx convention shows a pulsing skeleton (sidebar nav placeholder + 3 content blocks) while the RSC page.tsx renders. Dark theme, CSS animate-pulse, staggered delays.
 
 ### ~~QR-18: Graceful 404 for missing artifacts~~ DONE
 - **Status:** DONE — PR opened 2026-04-04. Created `src/app/[slug]/not-found.tsx` — branded dark-theme 404 with "This document doesn't exist" heading and "Create your own" CTA to sharestrata.com. `page.tsx` unchanged.

--- a/src/app/[slug]/loading.tsx
+++ b/src/app/[slug]/loading.tsx
@@ -1,0 +1,83 @@
+export default function ArtifactLoading() {
+  return (
+    <div
+      className="min-h-screen flex"
+      style={{ backgroundColor: "var(--color-background)" }}
+    >
+      {/* Sidebar skeleton — desktop only */}
+      <aside
+        className="hidden lg:flex flex-col shrink-0 border-r"
+        style={{
+          width: "var(--sidebar-width, 240px)",
+          borderColor: "rgba(255,255,255,0.10)",
+          position: "fixed",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          padding: "24px 16px",
+          gap: "8px",
+        }}
+      >
+        {/* Logo / title block */}
+        <div className="space-y-2 mb-6">
+          <div
+            className="h-4 rounded animate-pulse"
+            style={{ width: "70%", backgroundColor: "rgba(255,255,255,0.08)" }}
+          />
+          <div
+            className="h-3 rounded animate-pulse"
+            style={{ width: "50%", backgroundColor: "rgba(255,255,255,0.05)" }}
+          />
+        </div>
+        {/* Nav item skeletons */}
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-8 rounded-lg animate-pulse"
+            style={{
+              backgroundColor: "rgba(255,255,255,0.05)",
+              animationDelay: `${i * 80}ms`,
+            }}
+          />
+        ))}
+      </aside>
+
+      {/* Main content skeleton */}
+      <main
+        className="flex-1 flex flex-col items-center justify-start px-6 py-16 lg:ml-[var(--sidebar-width,240px)]"
+        style={{ maxWidth: "100%" }}
+      >
+        <div className="w-full" style={{ maxWidth: "900px" }}>
+          {/* Section title */}
+          <div
+            className="h-8 rounded-lg animate-pulse mb-3"
+            style={{ width: "55%", backgroundColor: "rgba(255,255,255,0.08)" }}
+          />
+          {/* Section subtitle */}
+          <div
+            className="h-4 rounded animate-pulse mb-12"
+            style={{ width: "38%", backgroundColor: "rgba(255,255,255,0.05)" }}
+          />
+
+          {/* Content block 1 */}
+          <div
+            className="h-48 rounded-xl animate-pulse mb-6"
+            style={{ backgroundColor: "rgba(255,255,255,0.05)", animationDelay: "100ms" }}
+          />
+
+          {/* Content block 2 */}
+          <div
+            className="h-32 rounded-xl animate-pulse mb-6"
+            style={{ backgroundColor: "rgba(255,255,255,0.05)", animationDelay: "180ms" }}
+          />
+
+          {/* Content block 3 */}
+          <div
+            className="h-40 rounded-xl animate-pulse"
+            style={{ backgroundColor: "rgba(255,255,255,0.05)", animationDelay: "260ms" }}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
Created `src/app/[slug]/loading.tsx` — the Next.js App Router `loading.tsx` convention. When present, Next.js wraps the route in a Suspense boundary and shows this file as the fallback while the RSC `page.tsx` is server-rendering (i.e., while Supabase fetches the artifact).

The skeleton matches the artifact viewer layout:
- **Sidebar placeholder** (desktop only, `lg:flex`) — logo/title block + 6 nav item rows with staggered `animate-pulse`
- **Main content** — section title block, subtitle block, and 3 content-area blocks (heights 192px, 128px, 160px) with staggered animation delays

All colors use CSS opacity layers (`rgba(255,255,255,0.08)` / `rgba(255,255,255,0.05)`) matching the design system opacity spec. Dark background from `--color-background` CSS variable.

## Why
With `export const dynamic = "force-dynamic"` on the page, the Supabase fetch always runs server-side on every request. Users saw a 1-2 second blank white/black flash before content arrived. The skeleton gives immediate visual feedback and makes the app feel responsive.

## Rubric item
QR-17 — Priority 5: Viewer Quality (investor-facing surface)

## Files modified
- `src/app/[slug]/loading.tsx` (new file)
- `docs/quality-rubric.md` (QR-17 marked DONE)

## Tier
**Tier 1** — visual polish, no behavior change. Loading skeleton is a progressive enhancement with zero functional impact.

https://claude.ai/code/session_014duFMLDxJ4sRx7NMe489Ch