### PR TITLE
Add aria-label to email input in AuthModal

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -168,6 +168,7 @@ export function AuthModal({ open, onClose, redirectTo }: AuthModalProps) {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="you@company.com"
+                aria-label="Email address"
                 onKeyDown={(e) => e.key === "Enter" && handleMagicLink()}
                 className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
               />


### PR DESCRIPTION
## What changed
Added `aria-label="Email address"` to the magic link email input in `AuthModal.tsx`.

## Why
The design system requires all form inputs to have an associated `<label>` or `aria-label`. This input had only a `placeholder`, which screen readers do not announce as a label — the field name disappears once the user starts typing.

## Files modified
- `src/components/auth/AuthModal.tsx`

## Tier
**Tier 0** — attribute-only change, zero visual or behavior impact.

https://claude.ai/code/session_014duFMLDxJ4sRx7NMe489Ch