### PR TITLE
Associate label elements with inputs via htmlFor/id in create page

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -308,10 +308,11 @@ export default function CreatePage() {
 
             <div className="mt-8 space-y-4">
               <div>
-                <label className="text-sm font-medium text-muted">
+                <label htmlFor="create-title" className="text-sm font-medium text-muted">
                   Title (optional — AI will generate one if blank)
                 </label>
                 <input
+                  id="create-title"
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
@@ -385,10 +386,11 @@ export default function CreatePage() {
 
               {/* Raw content textarea */}
               <div>
-                <label className="text-sm font-medium text-muted">
+                <label htmlFor="create-content" className="text-sm font-medium text-muted">
                   Raw content
                 </label>
                 <textarea
+                  id="create-content"
                   value={content}
                   onChange={(e) => { setContent(e.target.value); if (pdfFileName) setPdfFileName(null); }}
                   placeholder="Paste your strategy notes, outlines, bullet points, docs — anything you want to turn into an interactive artifact..."


### PR DESCRIPTION
## What changed
Added htmlFor to two label elements and matching id attributes to their inputs in src/app/create/page.tsx:
- id=create-title on the title input, htmlFor=create-title on its label
- id=create-content on the raw content textarea, htmlFor=create-content on its label

## Why
Design system requires form inputs to have an associated label or aria-label. Screen readers need the programmatic association to announce the field name. Without htmlFor, clicking the label also does not move focus to the input.

## Files modified
- src/app/create/page.tsx

## Tier
Tier 0 — attribute-only additions, zero visual or behavior change.

https://claude.ai/code/session_014duFMLDxJ4sRx7NMe489Ch