### PR TITLE
Add aria-label to unlabeled select elements in editor (chart type, phase)

### DIFF
--- a/src/components/editor/EditableDataViz.tsx
+++ b/src/components/editor/EditableDataViz.tsx
@@ -64,6 +64,7 @@ export function EditableDataViz({
         <label className="text-sm text-muted-foreground">Chart type:</label>
         <select
           value={section.content.chart_type}
+          aria-label="Chart type"
           onChange={(e) =>
             onFieldChange("content.chart_type", e.target.value)
           }

--- a/src/components/editor/EditableGuidedJourney.tsx
+++ b/src/components/editor/EditableGuidedJourney.tsx
@@ -259,6 +259,7 @@ function EventsEditor({
                 </label>
                 <select
                   value={event.phase_id}
+                  aria-label="Phase"
                   onChange={(e) =>
                     onFieldChange(
                       `content.events.${i}.phase_id`,


### PR DESCRIPTION
## What changed
Added aria-label attributes to two select elements in editor components that had adjacent visible labels but no programmatic association:
- EditableDataViz.tsx: chart type select gets aria-label="Chart type"
- EditableGuidedJourney.tsx: Phase select inside event rows gets aria-label="Phase" (this select is rendered inside a map, making htmlFor/id pairs impractical)

## Why
Design system requires all form inputs to have an associated label or aria-label. Screen readers need the programmatic association to announce the control purpose. The existing visible text labels ("Chart type:" and "Phase") are not announced as labels without either htmlFor/id pairing or aria-label.

## Files modified
- src/components/editor/EditableDataViz.tsx
- src/components/editor/EditableGuidedJourney.tsx

## Tier
Tier 0 - attribute-only change, zero visual or behavior impact.

https://claude.ai/code/session_014duFMLDxJ4sRx7NMe489Ch