### PR TITLE
Add aria-label to close button in MobilePreviewSheet

### DIFF
--- a/src/components/editor/MobilePreviewSheet.tsx
+++ b/src/components/editor/MobilePreviewSheet.tsx
@@ -64,6 +64,7 @@ export function MobilePreviewSheet({
               <span className="text-sm font-medium">Preview</span>
               <button
                 onClick={onClose}
+                aria-label="Close preview"
                 className="text-muted-foreground hover:text-foreground transition-colors"
               >
                 <XIcon className="w-4 h-4" />


### PR DESCRIPTION
## What changed
Added aria-label="Close preview" to the icon-only X button in MobilePreviewSheet.tsx.

## Why
Design system rule: all icon-only buttons must have aria-label. This button renders an XIcon with no visible text — without aria-label, screen readers announce it as an unlabeled button.

Existing PRs #18 (editor components) and #60 (auth modals) addressed other close buttons but MobilePreviewSheet.tsx was not covered.

## Files modified
- src/components/editor/MobilePreviewSheet.tsx

## Tier
Tier 0 - attribute-only change, zero visual or behavior impact.

https://claude.ai/code/session_014duFMLDxJ4sRx7NMe489Ch