### PR TITLE
Add keyboard focus and Enter activation to InlineEditor display mode

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -55,11 +55,20 @@ export function InlineEditor({
   if (!isEditing) {
     return (
       <span
+        role="button"
+        tabIndex={0}
+        aria-label={value || placeholder}
         onClick={(e) => {
           e.stopPropagation();
           setIsEditing(true);
         }}
-        className={`block w-full cursor-text rounded transition-all hover:ring-1 hover:ring-accent/30 hover:bg-accent/5 break-words ${
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setIsEditing(true);
+          }
+        }}
+        className={`block w-full cursor-text rounded transition-all hover:ring-1 hover:ring-accent/30 hover:bg-accent/5 break-words focus:outline-none focus:ring-1 focus:ring-accent/30 ${
           !value ? "text-muted-foreground italic" : ""
         } ${className}`}
       >


### PR DESCRIPTION
## What changed
Made the click-to-edit span in InlineEditor.tsx keyboard accessible:
- Added `tabIndex={0}` so the element is in the tab order
- Added `role="button"` to indicate it is interactive
- Added `aria-label` (the current value, or placeholder if empty) for screen reader announcement
- Added `onKeyDown` handler: Enter or Space activates edit mode (matching button behavior expected by screen readers when role=button)
- Added `focus:outline-none focus:ring-1 focus:ring-accent/30` focus ring to match the inline editor design system pattern

## Why
Design system accessibility minimum: "All interactive elements: focusable via Tab." The display-mode span had an onClick handler but was not in the tab order and had no keyboard activation path. Keyboard-only users and screen reader users had no way to enter edit mode without a mouse.

## Files modified
- `src/components/editor/InlineEditor.tsx`

## Tier
**Tier 1** — adds keyboard accessibility to an existing interaction. No visual change for mouse users. The focus ring (accent/30) matches the existing hover ring.

https://claude.ai/code/session_014duFMLDxJ4sRx7NMe489Ch