### PR TITLE
Add aria-label to nav elements in discover page and SidebarNav

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -57,7 +57,7 @@ export default function DiscoverPage() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       {/* Subtle top bar */}
-      <nav className="fixed top-0 left-0 right-0 z-50 border-b border-white/10 bg-background/80 backdrop-blur-md">
+      <nav aria-label="Main navigation" className="fixed top-0 left-0 right-0 z-50 border-b border-white/10 bg-background/80 backdrop-blur-md">
         <div className="mx-auto max-w-3xl px-6 py-4 flex items-center justify-between">
           <Link
             href="/"

--- a/src/components/viewer/SidebarNav.tsx
+++ b/src/components/viewer/SidebarNav.tsx
@@ -107,7 +107,7 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
         </div>
 
         {/* Navigation items */}
-        <nav className="flex-1 overflow-y-auto px-3 py-4">
+        <nav aria-label="Document sections" className="flex-1 overflow-y-auto px-3 py-4">
           <ul className="space-y-1">
             {items.map((item, index) => (
               <li key={item.id}>


### PR DESCRIPTION
## What changed
- `src/app/discover/page.tsx`: added `aria-label="Main navigation"` to the top navbar
- `src/components/viewer/SidebarNav.tsx`: added `aria-label="Document sections"` to the document navigation list

## Why
WAI-ARIA best practice: when a page has multiple navigational landmarks (or when a nav element's purpose is not obvious from context), it should have an aria-label so screen reader users can distinguish between them via landmark navigation. The discover page nav is the site header. The SidebarNav nav is the document section jump list.

## Files modified
- `src/app/discover/page.tsx`
- `src/components/viewer/SidebarNav.tsx`

## Tier
Tier 0 - attribute-only change, zero visual or behavior impact.

https://claude.ai/code/session_014duFMLDxJ4sRx7NMe489Ch