### PR TITLE
Normalize disabled:opacity-50 to disabled:opacity-30 in 3 editor components

### DIFF
--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -204,7 +204,7 @@ function SectionImagePreview({
           <button
             onClick={handleExtractStructure}
             disabled={isExtracting}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           >
             {isExtracting ? (
               <Loader2 className="w-3 h-3 animate-spin" />

--- a/src/components/editor/LogoUpload.tsx
+++ b/src/components/editor/LogoUpload.tsx
@@ -113,7 +113,7 @@ export function LogoUpload({
         <button
           onClick={handleRemove}
           disabled={uploading}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         >
           <X className="h-3 w-3" />
           {uploading ? "Removing..." : "Remove"}

--- a/src/components/editor/TypeSelectorDropdown.tsx
+++ b/src/components/editor/TypeSelectorDropdown.tsx
@@ -119,7 +119,7 @@ export function TypeSelectorDropdown({
       <button
         onClick={() => !isLoading && setIsOpen((v) => !v)}
         disabled={isLoading}
-        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
       >
         {isLoading ? (
           <>


### PR DESCRIPTION
## What changed
Normalized `disabled:opacity-50` to `disabled:opacity-30` in 3 editor components:
- `TypeSelectorDropdown.tsx` — trigger button while type conversion is in progress
- `EditableSectionRenderer.tsx` — Extract Structure button while extracting
- `LogoUpload.tsx` — Remove button while upload is in progress

## Why
Design system specifies `disabled:opacity-30 disabled:cursor-not-allowed` for all buttons. `opacity-50` was a legacy value inconsistent with the 5 other components already using `opacity-30`.

Note: SplitViewLayout:336 and EditorLayout:540 also have this issue, but those lines also have `hover:border-white/40` covered by open PR #115. Fixing them here would cause a merge conflict — will resolve when #115 merges.

## Rubric item
Discovery — not on rubric. Design-system reference: Disabled State (all buttons): `disabled:opacity-30 disabled:cursor-not-allowed`.

## Files modified
- `src/components/editor/TypeSelectorDropdown.tsx`
- `src/components/editor/EditableSectionRenderer.tsx`
- `src/components/editor/LogoUpload.tsx`

## Tier
**Tier 0** — Token-only change. No behavior change.