### PR TITLE
Add aria-label to 2 icon-only buttons in AiChatPanel

### DIFF
--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -79,6 +79,7 @@ export function AiChatPanel({
             <button
               onClick={onClearHistory}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Clear chat history"
               title="Clear chat history"
             >
               <RotateCcw className="w-3 h-3" />
@@ -171,6 +172,7 @@ export function AiChatPanel({
           <button
             onClick={handleSend}
             disabled={!input.trim() || isLoading}
+            aria-label="Send message"
             className="p-2 text-muted-foreground hover:text-accent disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-muted-foreground transition-colors shrink-0"
           >
             <Send className="w-4 h-4" />


### PR DESCRIPTION
## What changed
Added `aria-label` to 2 icon-only buttons in `AiChatPanel.tsx` that had no accessible label for screen readers:

1. **Clear history button** (RotateCcw icon) — had `title="Clear chat history"` but not `aria-label`. Added `aria-label="Clear chat history"`.
2. **Send message button** (Send icon) — had no label at all. Added `aria-label="Send message"`.

## Why
Design system Accessibility Minimums: "All icon-only buttons: `aria-label="[action]"`". These were the remaining 2 icon-only buttons in AiChatPanel without proper labeling. (Apply/Discard buttons have text, so they didn't need labels.)

## Rubric item
Discovery (QR-15 family). Design-system ref: Accessibility Minimums.

## Files modified
- `src/components/editor/AiChatPanel.tsx`

## Tier
**Tier 0** — ARIA attribute only. No visual or behavior change.