### PR TITLE
Add aria-label to sidebar overlay close button in SplitViewLayout

### DIFF
--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -254,6 +254,7 @@ export function SplitViewLayout({
                   </div>
                   <button
                     onClick={handleCloseSidebarOverlay}
+                    aria-label="Close panel"
                     className="text-muted-foreground hover:text-foreground transition-colors"
                   >
                     <XIcon className="w-4 h-4" />


### PR DESCRIPTION
## What changed
Added `aria-label="Close panel"` to the XIcon button that closes the mobile sidebar overlay in `SplitViewLayout.tsx`.

## Why
The button was icon-only with no accessible label. Design system Accessibility Minimums: all icon-only buttons must have `aria-label="[action]"`.

## Rubric item
Discovery (QR-15 family).

## Files modified
- `src/components/editor/SplitViewLayout.tsx`

## Tier
**Tier 0** — ARIA attribute only. No visual or behavior change.