### PR TITLE
Add aria-label to AI chat textarea and DocumentSettings color inputs

### DIFF
--- a/src/components/editor/AiChatPanel.tsx
+++ b/src/components/editor/AiChatPanel.tsx
@@ -165,6 +165,7 @@ export function AiChatPanel({
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Describe what to change..."
+            aria-label="Describe what to change"
             rows={1}
             className="flex-1 bg-transparent px-3 py-2.5 text-sm outline-none placeholder:text-muted-foreground/50 resize-none max-h-24 overflow-y-auto"
           />

--- a/src/components/editor/DocumentSettings.tsx
+++ b/src/components/editor/DocumentSettings.tsx
@@ -95,6 +95,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
               value={primary}
               onChange={(e) => handlePrimaryChange(e.target.value)}
               className="w-8 h-8 rounded cursor-pointer border border-white/20"
+              aria-label="Primary color"
               title="Primary color"
             />
             <span className="text-xs text-muted-foreground">Primary</span>
@@ -106,6 +107,7 @@ export function DocumentSettings({ artifact, onUpdate }: DocumentSettingsProps) 
               value={secondary}
               onChange={(e) => handleSecondaryChange(e.target.value)}
               className="w-8 h-8 rounded cursor-pointer border border-white/20"
+              aria-label="Secondary color"
               title="Secondary color"
             />
             <span className="text-xs text-muted-foreground">Secondary</span>


### PR DESCRIPTION
## What changed
Added `aria-label` to 3 form inputs missing proper accessible labels:

1. **AiChatPanel.tsx** — main chat textarea had no `aria-label` (placeholder is not an accessible label for screen readers)
2. **DocumentSettings.tsx** — both color pickers (`<input type="color">`) had `title=` only; screen readers prefer `aria-label` over `title` for inputs

## Why
Design system Accessibility Minimums: "Form inputs: associated `<label>` or `aria-label`."

## Rubric item
Discovery (QR-15 family — form input accessibility).

## Files modified
- `src/components/editor/AiChatPanel.tsx`
- `src/components/editor/DocumentSettings.tsx`

## Tier
**Tier 0** — ARIA attributes only. No visual or behavior change.