### PR TITLE
Normalize p-5 to p-4 in GuidedJourney event card

### DIFF
--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -385,7 +385,7 @@ function DetailPanel({
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="rounded-xl border bg-card p-5"
+      className="rounded-xl border bg-card p-4"
       style={{ borderColor: color + "40" }}
     >
       {/* Header */}


### PR DESCRIPTION
## What changed

Normalized `p-5` to `p-4` in the GuidedJourney event detail card (`GuidedJourney.tsx` line 388).

## Why

`p-5` (20px) is not in the design system standard spacing table. The table specifies:
- `p-2` — small cards, compact sections
- `p-3` / `p-4` — panel content, form sections
- `p-6` — editor main content area
- `p-8` — upload zones, empty states

Other cards in the same component already use `p-4` (line 138). Normalizing keeps spacing consistent throughout the component.

## Which rubric item

Off-rubric discovery (design system spacing normalization).

## Files modified

- `src/components/viewer/sections/GuidedJourney.tsx` — 1 line changed

## Tier

**Tier 0** — token-only change, no behavior change possible.