### PR TITLE
Normalize text-[9px] to text-[10px] in GuidedJourney event label

### DIFF
--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -347,7 +347,7 @@ function TimelineTrack({
                     </span>
                     <span
                       className={cn(
-                        "mt-0.5 max-w-[80px] text-center text-[9px] leading-tight transition-colors whitespace-nowrap",
+                        "mt-0.5 max-w-[80px] text-center text-[10px] leading-tight transition-colors whitespace-nowrap",
                         isActive
                           ? "font-semibold"
                           : "text-muted opacity-50"


### PR DESCRIPTION
## What changed
Replaced `text-[9px]` with `text-[10px]` on the event label span in `GuidedJourney.tsx` (the label beneath each day number in the horizontal timeline track).

## Why
`text-[9px]` is on the design system kill list — it must be normalized to `text-[10px]` (the minimum allowed size for labels, metadata, and hints).

## Rubric item
Discovery — not on rubric. No prior PR covered this instance.

## Files modified
- `src/components/viewer/sections/GuidedJourney.tsx` (1 line)

## Tier
**Tier 0** — token-only change, no behavior change possible.