### PR TITLE
Normalize disabled opacity to 30 on Play/Pause control buttons in GuidedJourney viewer

### DIFF
--- a/src/components/viewer/sections/GuidedJourney.tsx
+++ b/src/components/viewer/sections/GuidedJourney.tsx
@@ -551,7 +551,7 @@ export function GuidedJourney({
             className={cn(
               "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-all",
               isPlaying
-                ? "opacity-50 cursor-not-allowed bg-card border border-border text-muted"
+                ? "opacity-30 cursor-not-allowed bg-card border border-border text-muted"
                 : "bg-[var(--palette-accent1,#2fd8c8)] text-background hover:opacity-90"
             )}
           >
@@ -565,7 +565,7 @@ export function GuidedJourney({
             className={cn(
               "flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium transition-all",
               !isPlaying
-                ? "opacity-40 cursor-not-allowed text-muted"
+                ? "opacity-30 cursor-not-allowed text-muted"
                 : "hover:bg-card text-foreground"
             )}
           >


### PR DESCRIPTION
## What changed
Normalized the disabled-state opacity values on the Play and Pause control buttons in `GuidedJourney.tsx`:
- Play button: `opacity-50` → `opacity-30` (disabled when journey is playing)
- Pause button: `opacity-40` → `opacity-30` (disabled when journey is stopped)

## Why
Design system rule: all disabled buttons use `opacity-30 cursor-not-allowed`. `opacity-50` and `opacity-40` are both non-standard values not in the opacity system.

## Rubric item
Discovery — not on rubric. Not covered by any existing open PR. (PR #21 covers editor buttons; PR #61 covers AuthModal; neither covers viewer component control buttons.)

## Files modified
- `src/components/viewer/sections/GuidedJourney.tsx` (2 lines)

## Tier
**Tier 0** — token-only value change, no behavior change possible.