### PR TITLE
Add aria-label to feature toggle and remove buttons in TierTable editor

### DIFF
--- a/src/components/editor/EditableSectionRenderer.tsx
+++ b/src/components/editor/EditableSectionRenderer.tsx
@@ -772,6 +772,7 @@ function EditableTierTable({
               <li key={`${feat.name}-${j}`} className="group/feat text-sm flex items-center gap-2">
                 <button
                   onClick={() => handleToggleIncluded(i, j)}
+                  aria-label={feat.included ? "Mark feature as not included" : "Mark feature as included"}
                   className="text-xs w-4 text-center hover:text-accent transition-colors"
                 >
                   {feat.included ? "+" : "−"}
@@ -784,6 +785,7 @@ function EditableTierTable({
                 </span>
                 <button
                   onClick={() => handleRemoveFeature(i, j)}
+                  aria-label="Remove feature"
                   className="opacity-0 group-hover/feat:opacity-50 hover:!opacity-100 hover:text-red-400 transition-opacity text-xs"
                 >
                   ×


### PR DESCRIPTION
## What changed
Added `aria-label` attributes to two symbol-text buttons in the tier-table feature row editor (`EditableSectionRenderer.tsx`):

1. **Feature toggle button** (`+`/`−`): `aria-label={feat.included ? "Mark feature as not included" : "Mark feature as included"}` — label reflects current toggle state
2. **Remove feature button** (`×`): `aria-label="Remove feature"` — the × character is ambiguous to screen readers

## Why
Design system accessibility rule: all buttons with ambiguous/symbolic text content need `aria-label`. The `+`, `−`, and `×` symbols read as "plus", "minus", and "multiplication sign" to screen readers — meaningless without label. These buttons were not covered by any existing open PR (PRs #7, #18 cover other files; PR #137 covers focus rings in the same file but not aria-labels).

## Rubric item
Discovery — partial QR-15 coverage. Not covered by any existing open PR.

## Files modified
- `src/components/editor/EditableSectionRenderer.tsx` (2 lines)

## Tier
**Tier 0** — attribute additions only, no visual or behavior change.