### PR TITLE
Add aria-hidden to mobile navigation overlay backdrop in SidebarNav

### DIFF
--- a/src/components/viewer/SidebarNav.tsx
+++ b/src/components/viewer/SidebarNav.tsx
@@ -159,6 +159,7 @@ export function SidebarNav({ items, title, subtitle, logoUrl }: SidebarNavProps)
       {/* Mobile overlay */}
       {mobileOpen && (
         <div
+          aria-hidden="true"
           className="fixed inset-0 z-30 bg-black/50 lg:hidden"
           onClick={() => setMobileOpen(false)}
         />


### PR DESCRIPTION
## What changed
Added `aria-hidden="true"` to the mobile overlay backdrop `<div>` in `SidebarNav.tsx`.

## Why
The backdrop div (`bg-black/50 fixed inset-0`) is a decorative overlay that lets mouse users close the sidebar by clicking outside. Screen readers should not land on it — the accessible close path for keyboard/screen-reader users is the "Toggle navigation" button which already has `aria-label="Toggle navigation"`. Without `aria-hidden`, screen readers may encounter this empty clickable div and be confused.

## Rubric item
Discovery — not on rubric. Not covered by any existing open PR (PR #63 covers decorative SVGs; PR #135 covers `<nav>` aria-labels; PR #141 covers the editor sidebar close button).

## Files modified
- `src/components/viewer/SidebarNav.tsx` (1 line)

## Tier
**Tier 0** — attribute addition only, no visual or behavior change.