### PR TITLE
Add aria-hidden to overlay backdrop divs in MobilePreviewSheet and SplitViewLayout

### DIFF
--- a/src/components/editor/MobilePreviewSheet.tsx
+++ b/src/components/editor/MobilePreviewSheet.tsx
@@ -33,6 +33,7 @@ export function MobilePreviewSheet({
         <>
           {/* Backdrop */}
           <motion.div
+            aria-hidden="true"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}

--- a/src/components/editor/SplitViewLayout.tsx
+++ b/src/components/editor/SplitViewLayout.tsx
@@ -221,6 +221,7 @@ export function SplitViewLayout({
           <>
             {/* Backdrop */}
             <motion.div
+              aria-hidden="true"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
@@ -377,6 +378,7 @@ export function SplitViewLayout({
         {showShortcuts && (
           <>
             <motion.div
+              aria-hidden="true"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}


### PR DESCRIPTION
## What changed
Added `aria-hidden="true"` to three clickable backdrop overlay `motion.div` elements:
1. `MobilePreviewSheet.tsx` — preview sheet backdrop
2. `SplitViewLayout.tsx` — sidebar expand backdrop
3. `SplitViewLayout.tsx` — keyboard shortcuts overlay backdrop

## Why
Design system accessibility rule: decorative elements that are not interactive for keyboard/screen-reader users should be hidden from the accessibility tree. These backdrops let mouse users close panels by clicking outside, but keyboard/screen-reader users have dedicated close buttons or the Escape key. Without `aria-hidden`, screen readers may unexpectedly land on an empty, unnamed interactive div.

## Rubric item
Discovery — not on rubric. Not covered by any existing open PR. (PR #149 covers the viewer SidebarNav overlay with the same pattern; this PR covers the editor component overlays.)

## Files modified
- `src/components/editor/MobilePreviewSheet.tsx` (1 line)
- `src/components/editor/SplitViewLayout.tsx` (2 lines)

## Tier
**Tier 0** — attribute additions only, no visual or behavior change.