### PR TITLE
Add aria-hidden to decorative shimmer animation divs in EditorLayout

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -683,7 +683,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                           </button>
                         </div>
                         {/* Shimmer animation */}
-                        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent animate-pulse" />
+                        <div aria-hidden="true" className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent animate-pulse" />
                       </div>
                     )}
 
@@ -711,7 +711,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                         }
                       />
                       {chat.isLoading && editor.selectedSectionId === section.id && (
-                        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent animate-pulse rounded-lg" />
+                        <div aria-hidden="true" className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent animate-pulse rounded-lg" />
                       )}
                     </div>
                   </div>
@@ -753,7 +753,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                       Cancel
                     </button>
                   </div>
-                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent animate-pulse" />
+                  <div aria-hidden="true" className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent animate-pulse" />
                 </div>
               )}
 


### PR DESCRIPTION
## What changed
Added `aria-hidden="true"` to 3 decorative shimmer animation `<div>` elements in `EditorLayout.tsx`:
1. Image section upload loading shimmer (during image upload)
2. AI chat loading shimmer overlay on section being edited
3. Image drop zone upload shimmer (during drop-zone upload)

## Why
Design system accessibility rule: decorative visual elements with no content should be hidden from the accessibility tree. These shimmer divs are pure CSS animation effects (`bg-gradient-to-r ... animate-pulse`) that create a loading shimmer. Without `aria-hidden`, screen readers may encounter these empty decorative divs. The loading state is already communicated by the descriptive text "Uploading image..." and spinner icons nearby.

## Rubric item
Discovery — not on rubric. Not covered by any existing open PR. (PR #63 covers decorative SVGs; this covers decorative shimmer divs in EditorLayout.)

## Files modified
- `src/components/editor/EditorLayout.tsx` (3 lines)

## Tier
**Tier 0** — attribute additions only, no visual or behavior change.