### PR TITLE
Add aria-hidden to modal backdrops and upload image preview backgrounds

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -67,6 +67,7 @@ export function AuthModal({ open, onClose, redirectTo }: AuthModalProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
+        aria-hidden="true"
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={onClose}
       />

--- a/src/components/auth/UpgradePrompt.tsx
+++ b/src/components/auth/UpgradePrompt.tsx
@@ -29,6 +29,7 @@ export function UpgradePrompt({
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
+        aria-hidden="true"
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={onClose}
       />

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -662,6 +662,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                       <div className="relative rounded-xl border border-dashed border-accent/40 bg-accent/5 p-8 mb-8 overflow-hidden">
                         {pendingImagePreview && (
                           <div
+                            aria-hidden="true"
                             className="absolute inset-0 bg-cover bg-center opacity-10"
                             style={{ backgroundImage: `url(${pendingImagePreview})` }}
                           />
@@ -735,6 +736,7 @@ export function EditorLayout({ initialArtifact }: { initialArtifact: Artifact })
                 <div className="relative rounded-xl border border-dashed border-accent/40 bg-accent/5 p-8 overflow-hidden">
                   {pendingImagePreview && (
                     <div
+                      aria-hidden="true"
                       className="absolute inset-0 bg-cover bg-center opacity-10"
                       style={{ backgroundImage: `url(${pendingImagePreview})` }}
                     />


### PR DESCRIPTION
## What changed
Added `aria-hidden="true"` to 4 decorative background/backdrop elements:
1. `AuthModal.tsx` — click-to-close modal backdrop (`bg-black/60 backdrop-blur-sm`)
2. `UpgradePrompt.tsx` — click-to-close modal backdrop (`bg-black/60 backdrop-blur-sm`)
3. `EditorLayout.tsx` (line 665) — image preview background at 10% opacity shown during upload at section position
4. `EditorLayout.tsx` (line 738) — same image preview background at end-of-list position

## Why
Design system accessibility rule: decorative elements that convey no information should be hidden from the accessibility tree with `aria-hidden="true"`. Modal backdrops are click-to-close helpers for mouse users; keyboard/screen-reader users close modals via the close button (PR #60 adds `aria-label="Close"` to those). Image preview backgrounds are purely visual decoration during upload — the loading state is communicated by "Uploading image..." text and spinner.

## Rubric item
Discovery — not on rubric. Not covered by any existing open PR. (PR #149 covers viewer SidebarNav overlay; PR #150 covers editor SplitViewLayout/MobilePreviewSheet overlays; this PR covers auth modal backdrops and EditorLayout image backgrounds.)

## Files modified
- `src/components/auth/AuthModal.tsx` (1 line)
- `src/components/auth/UpgradePrompt.tsx` (1 line)
- `src/components/editor/EditorLayout.tsx` (2 lines)

## Tier
**Tier 0** — attribute additions only, no visual or behavior change.