### PR TITLE
Add aria-label to drag handle and remove buttons in ItemManager

### DIFF
--- a/src/components/editor/ItemManager.tsx
+++ b/src/components/editor/ItemManager.tsx
@@ -60,6 +60,7 @@ function SortableRow({
       <button
         {...attributes}
         {...listeners}
+        aria-label="Drag to reorder"
         className="mt-3 opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none transition-opacity"
         tabIndex={-1}
       >
@@ -69,6 +70,7 @@ function SortableRow({
       {canRemove && (
         <button
           onClick={onRemove}
+          aria-label="Remove item"
           className="mt-3 opacity-0 group-hover:opacity-50 hover:!opacity-100 hover:text-red-400 transition-opacity shrink-0"
           tabIndex={-1}
         >


### PR DESCRIPTION
## What changed
Added `aria-label` to two icon-only buttons in `ItemManager.tsx`:
- Drag handle button (GripVertical icon): `aria-label="Drag to reorder"`
- Remove item button (Trash2 icon): `aria-label="Remove item"`

## Why
Screen readers had no way to describe these buttons' purpose. Every icon-only interactive element must have an accessible label per the design system's accessibility minimums.

## Rubric item
QR-15 — ARIA labels on all icon-only buttons | Tier 0

## Files modified
- `src/components/editor/ItemManager.tsx` (+2 lines)

## Verification
- `npm run build` passes with 0 errors
- Both buttons now have `aria-label`