### PR TITLE
Add loading skeleton to section editor during type conversion

### DIFF
--- a/docs/agents/quality/history.md
+++ b/docs/agents/quality/history.md
@@ -11,6 +11,11 @@ Format:
 
 ---
 
+## 2026-04-15
+
+- PR #194 | QR-13 | tier-1 | open | Add loading skeleton to section editor during type conversion
+- PR #193 | QR-15 | tier-0 | open | Add aria-label to drag handle and remove buttons in ItemManager
+
 ## 2026-04-04
 
 - PR #2 | QR-02 | tier-1 | merged | Unified editor button patterns to 3 standard variants

--- a/docs/agents/quality/scratchpad.md
+++ b/docs/agents/quality/scratchpad.md
@@ -10,6 +10,12 @@ Working through Tier 1 items in `docs/quality-rubric.md`. Next unblocked item af
 
 *(Patterns that worked. Append newest at top.)*
 
+### 2026-04-15 — Twenty-second run: 2 PRs (1 Tier 0, 1 Tier 1), 2 rubric items closed
+- QR-15 (icon-only aria-labels): after 21 previous runs, only 2 buttons remained — `ItemManager.tsx` drag handle (GripVertical) and remove (Trash2). All others in editor had been fixed. Comprehensive grep + manual file review was the right approach; don't trust the initial agent report alone.
+- QR-13 (loading skeleton): the 5s error persistence timer was present since the original implementation — the rubric description was outdated. The actual missing piece was the loading skeleton during AI remap. Solution: `onLoadingChange` prop on TypeSelectorDropdown → `isRemapping` state in SectionEditorPanel → animate-pulse skeleton replaces EditableSectionRenderer content.
+- GitHub PAT in ~/.zshrc (`GITHUB_PERSONAL_ACCESS_TOKEN`) was expired — use `gh` CLI directly for all GitHub operations; it uses keyring auth which stays valid.
+- With all rubric items now closed or blocked, the next work should focus on discovering new quality issues via codebase audit or waiting for planning session (QR-24, QR-16).
+
 ### 2026-04-05 — Nineteenth run: 6 PRs (all Tier 0), 2 rubric items closed
 - QR-03 and QR-13 were both effectively fixed in main but never marked done — audit the rubric against current code at start of run, not just "is status OPEN?"
 - `focus:outline-none focus:border-white/20` is a non-standard focus ring pattern; design system says `outline-none focus:ring-1 focus:ring-accent/50`. Found in 4 inputs in EditableSectionRenderer (tier-table card editor, callout textarea).

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -62,12 +62,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 ### ~~QR-12: Consistent hover states on sidebar items~~ DONE
 - **Status:** DONE — PR #11
 
-### QR-13: Type selector dropdown polish
-- **Tier:** 1
-- **What:** Type selector error appears as toast above dropdown but disappears when dropdown closes. Make error persist for 5s regardless of dropdown state. Also add loading skeleton during type conversion.
-- **Files:** `src/components/editor/TypeSelectorDropdown.tsx`
-- **Test:** Trigger type change error — close dropdown — error still visible for 5s
-- **Status:** OPEN
+### ~~QR-13: Type selector dropdown polish~~ DONE
+- **Status:** DONE — PR #194. Added `onLoadingChange` prop to `TypeSelectorDropdown` and pulsing skeleton in `SectionEditorPanel` during AI remap. Error persistence (5s timer) was already present in original implementation.
 
 ### ~~QR-22: Timeline dots should show status differentiation~~ DONE
 - **Status:** DONE — Already implemented in AnimatedTimeline.tsx via STATUS_STYLES object (accent dot + ArrowRight for current, success dot + Check for completed, card dot + Circle for upcoming). Rubric pre-dated the implementation.
@@ -90,12 +86,8 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 ### ~~QR-14: ARIA live regions for dynamic content~~ DONE
 - **Status:** DONE — PR #QR-14. Added `aria-live="polite"` to save status in TopBar, message list in AiChatPanel, and all 6 error message containers in editor components.
 
-### QR-15: ARIA labels on all icon-only buttons
-- **Tier:** 0
-- **What:** Every button that contains only an icon (no text) must have `aria-label`. Audit all editor components.
-- **Files:** All files in `src/components/editor/`
-- **Test:** `grep -r "className=.*w-[34].*h-[34]" src/components/editor/ | grep "<button"` — every match has `aria-label`
-- **Status:** OPEN
+### ~~QR-15: ARIA labels on all icon-only buttons~~ DONE
+- **Status:** DONE — PR #193. Added `aria-label="Drag to reorder"` and `aria-label="Remove item"` to the GripVertical drag handle and Trash2 remove buttons in `ItemManager.tsx`. All other icon-only buttons in editor components already had aria-labels.
 
 ---
 

--- a/src/components/editor/SectionEditorPanel.tsx
+++ b/src/components/editor/SectionEditorPanel.tsx
@@ -5,7 +5,7 @@ import type { Section } from "@/types/artifact";
 import { SECTION_TYPE_LABELS } from "@/types/artifact";
 import { EditableSectionRenderer } from "./EditableSectionRenderer";
 import { TypeSelectorDropdown } from "./TypeSelectorDropdown";
-import { Sparkles } from "lucide-react";
+import { Sparkles, Loader2 } from "lucide-react";
 
 interface SectionEditorPanelProps {
   section: Section;
@@ -24,6 +24,7 @@ export function SectionEditorPanel({
 }: SectionEditorPanelProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [pendingRemap, setPendingRemap] = useState<Section | null>(null);
+  const [isRemapping, setIsRemapping] = useState(false);
 
   // Scroll to top when switching sections
   useEffect(() => {
@@ -50,6 +51,7 @@ export function SectionEditorPanel({
               setPendingRemap(remapped);
               onPendingPreview?.(remapped);
             }}
+            onLoadingChange={setIsRemapping}
           />
         </div>
 
@@ -83,12 +85,28 @@ export function SectionEditorPanel({
         )}
 
         {/* Editable section content */}
-        <EditableSectionRenderer
-          section={section}
-          isSelected={true}
-          onFieldChange={(path, value) => onFieldChange(section.id, path, value)}
-          onReplaceSection={(updated) => onReplaceSection(section.id, updated)}
-        />
+        {isRemapping ? (
+          <div className="space-y-3 animate-pulse" aria-label="Converting section type" aria-busy="true">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              <span>Remapping content...</span>
+            </div>
+            <div className="h-6 bg-white/5 rounded w-3/4" />
+            <div className="h-4 bg-white/5 rounded w-full" />
+            <div className="h-4 bg-white/5 rounded w-5/6" />
+            <div className="h-4 bg-white/5 rounded w-4/5" />
+            <div className="h-20 bg-white/5 rounded w-full mt-4" />
+            <div className="h-4 bg-white/5 rounded w-2/3" />
+            <div className="h-4 bg-white/5 rounded w-3/4" />
+          </div>
+        ) : (
+          <EditableSectionRenderer
+            section={section}
+            isSelected={true}
+            onFieldChange={(path, value) => onFieldChange(section.id, path, value)}
+            onReplaceSection={(updated) => onReplaceSection(section.id, updated)}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/editor/TypeSelectorDropdown.tsx
+++ b/src/components/editor/TypeSelectorDropdown.tsx
@@ -23,11 +23,13 @@ const ALL_TYPES: SectionType[] = [
 interface TypeSelectorDropdownProps {
   section: Section;
   onTypeChange: (remappedSection: Section) => void;
+  onLoadingChange?: (loading: boolean) => void;
 }
 
 export function TypeSelectorDropdown({
   section,
   onTypeChange,
+  onLoadingChange,
 }: TypeSelectorDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -74,6 +76,7 @@ export function TypeSelectorDropdown({
     async (targetType: SectionType) => {
       setIsOpen(false);
       setIsLoading(true);
+      onLoadingChange?.(true);
       setPendingType(targetType);
       setError(null);
 
@@ -118,10 +121,11 @@ export function TypeSelectorDropdown({
         setError(msg);
       } finally {
         setIsLoading(false);
+        onLoadingChange?.(false);
         setPendingType(null);
       }
     },
-    [section, onTypeChange]
+    [section, onTypeChange, onLoadingChange]
   );
 
   const otherTypes = ALL_TYPES.filter((t) => t !== section.type);


### PR DESCRIPTION
## What changed

When a user selects a new section type, the AI remap call takes 5–15 seconds. Previously the editor still showed the old section content with only a small spinner in the type selector button — no signal that the content area was about to change.

Now `SectionEditorPanel` replaces the editable form with a pulsing skeleton while the remap is in progress, giving clear visual feedback that the content is being transformed.

### Before
- Small "Converting to X..." spinner in the type selector button only
- Old section content stays fully visible and appears interactive

### After  
- Type selector button still shows "Converting to X..." spinner
- Section editor area shows a pulsing skeleton (title line + content lines + large block placeholder)
- `aria-busy="true"` + `aria-label` for screen reader awareness

## Implementation

- `TypeSelectorDropdown`: added optional `onLoadingChange?: (loading: boolean) => void` prop — fires `true` when remap starts, `false` when it completes (success or error)
- `SectionEditorPanel`: tracks `isRemapping` state via `onLoadingChange`, conditionally renders skeleton or `EditableSectionRenderer`

The 5-second error persistence timer already existed and was not changed.

## Rubric item
QR-13 — Type selector dropdown polish | Tier 1

## Files modified
- `src/components/editor/TypeSelectorDropdown.tsx`
- `src/components/editor/SectionEditorPanel.tsx`

## Verification
- `npm run build` passes with 0 errors
- Build output: `✓ Compiled successfully`