### PR TITLE
Normalize design system tokens in ComparisonMatrix viewer section

### DIFF
--- a/src/components/viewer/sections/ComparisonMatrix.tsx
+++ b/src/components/viewer/sections/ComparisonMatrix.tsx
@@ -26,7 +26,7 @@ function DesktopTable({ section }: { section: ComparisonMatrixSection }) {
         <thead>
           <tr>
             {/* Row label column header */}
-            <th className="pb-3 pr-4 text-left text-xs font-semibold uppercase tracking-wider text-muted w-40" />
+            <th className="pb-3 pr-4 text-left text-xs font-medium uppercase tracking-wide text-muted w-40" />
             {columns.map((col, colIdx) => (
               <motion.th
                 key={col.id}
@@ -85,7 +85,7 @@ function DesktopTable({ section }: { section: ComparisonMatrixSection }) {
 
           {verdict && (
             <tr className="border-t-2 border-border bg-card-hover">
-              <td className="py-3 pr-4 text-xs font-semibold uppercase tracking-wider text-muted">
+              <td className="py-3 pr-4 text-xs font-medium uppercase tracking-wide text-muted">
                 {verdict.label}
               </td>
               {columns.map((col, colIdx) => (
@@ -129,7 +129,7 @@ function MobileStacked({ section }: { section: ComparisonMatrixSection }) {
           viewport={{ once: true, margin: "-50px" }}
           className="rounded-xl border border-border bg-card p-4"
         >
-          <p className="text-sm font-semibold text-foreground">{row.label}</p>
+          <p className="text-sm font-medium text-foreground">{row.label}</p>
           {row.description && (
             <p className="mt-0.5 text-xs text-muted">{row.description}</p>
           )}
@@ -167,7 +167,7 @@ function MobileStacked({ section }: { section: ComparisonMatrixSection }) {
           viewport={{ once: true, margin: "-50px" }}
           className="rounded-xl border border-border bg-card-hover p-4"
         >
-          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted">
+          <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
             {verdict.label}
           </p>
           <div className="grid grid-cols-2 gap-2">


### PR DESCRIPTION
## What changed

Tier 0 token normalization in `src/components/viewer/sections/ComparisonMatrix.tsx`. No behavior change.

**Violations fixed:**
- `font-semibold` → `font-medium` (4 instances: desktop table header label, desktop verdict label, mobile row label, mobile verdict label)
- `tracking-wider` → `tracking-wide` (3 instances: label pattern conformance with design system)

## Why

`ComparisonMatrix.tsx` was added in commit `d6815eb` as part of the new section types expansion and missed the design system audit. Discovery run caught it.

## Rubric item

Discovery — no rubric item number. Pure token normalization audit on newly-added file.

## Files modified

- `src/components/viewer/sections/ComparisonMatrix.tsx`