### PR TITLE
Discovery: visual consistency sweep — 3 new items (QR-25, QR-26, QR-27)

### DIFF
--- a/docs/agents/coordination-log.md
+++ b/docs/agents/coordination-log.md
@@ -1,5 +1,12 @@
 # Agent Coordination Log
 
+## 2026-04-15
+
+## 2026-04-15 14:15 ET — Discovery
+- Ran visual consistency sweep. Filed 3 new items: QR-25 (Regression text-[9px] in EditableSectionRenderer+GuidedJourney), QR-26 (non-standard ghost-accent button in AddSectionPaste), QR-27 (non-standard border-accent/40 in AddSectionUpload).
+- PR: https://github.com/jonmiller274-sudo/strata/pull/198
+- Next rotation: Interaction completeness sweep
+
 ## 2026-04-13
 
 - 10:55 | competitive-researcher | Self-audit: 4 checks, 3 gaps → GitHub Issue

--- a/docs/agents/discovery/audit-history.md
+++ b/docs/agents/discovery/audit-history.md
@@ -11,6 +11,10 @@ Format:
 
 ---
 
+## 2026-04-15
+
+- 14:15 | visual-consistency | src/components/editor/, src/components/viewer/sections/, AddSectionPaste.tsx, AddSectionUpload.tsx | 3 filed (QR-25, QR-26, QR-27) | Regression text-[9px] in EditableSectionRenderer+GuidedJourney; non-standard ghost-accent button in AddSectionPaste; non-standard border-accent/40 in AddSectionUpload
+
 ## 2026-04-04
 
 *(No audits run yet. First scheduled run pending.)*

--- a/docs/agents/discovery/scratchpad.md
+++ b/docs/agents/discovery/scratchpad.md
@@ -17,6 +17,10 @@ Discovery rotates through these audit types so no single mode goes stale:
 
 *(Which mode last ran. Append newest at top. Agent picks the oldest mode that hasn't run in the last 3 days.)*
 
+### 2026-04-15 14:15 — Visual consistency sweep
+Ran visual consistency sweep. Filed 3 new items: QR-25 (regression text-[9px]), QR-26 (non-standard button in AddSectionPaste), QR-27 (non-standard border-accent/40 in AddSectionUpload).
+Next rotation: **Interaction completeness sweep**.
+
 ### 2026-04-04 — Seeded
 No audits run yet. First scheduled run will start with **visual sweep** (deployed app vs design-system.md).
 
@@ -27,6 +31,12 @@ First audit queue is post-Phase-1 visual polish. After that, rotate through inte
 ## What I Learned
 
 *(Patterns Discovery noticed about where bugs tend to cluster. Append newest at top.)*
+
+### 2026-04-15 — New feature files skip design-system review
+New components added for the multi-format ingestion feature (AddSectionPaste, AddSectionUpload) introduced non-standard button and border patterns not caught by the Quality Engineer's existing sweeps. New feature files should be audited on the next visual sweep cycle — they tend to introduce one-off patterns that pre-date the design system conventions.
+
+### 2026-04-15 — Kill-list items can regress silently
+QR-01 (text-[9px] kill) was marked DONE but two instances of text-[9px] remain in the codebase — one in a newly-modified editor file, one in a viewer component. Kill-list items should be re-verified with a grep after any feature build, not assumed fixed permanently.
 
 ### 2026-04-04 — Seeded
 Nothing yet.

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -36,6 +36,30 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 ### ~~QR-21: Palette consistency audit — charts and active states should use Velocity palette~~ DONE
 - **Status:** DONE — PR #10
 
+### QR-25: Regression: QR-01 — text-[9px] persists in EditableSectionRenderer and GuidedJourney
+- **What:** Two components still use `text-[9px]`, which is on the design-system.md kill list ("normalize to text-[10px]"). QR-01 was marked DONE but these instances were missed or added afterward. EditableSectionRenderer uses it for column-header labels in the comparison table editor; GuidedJourney uses it for timeline node labels in the viewer. Both must be normalized to `text-[10px]`.
+- **Files:** `src/components/editor/EditableSectionRenderer.tsx:960`, `src/components/viewer/sections/GuidedJourney.tsx:350`
+- **Test:** `grep -rn "text-\[9px\]" src/components/` — must return 0 matches
+- **Priority:** 1
+- **Tier:** 0
+- **Status:** OPEN
+
+### QR-26: Non-standard primary action button variant in AddSectionPaste
+- **What:** The "Structure with AI" / "Import from URL" button in AddSectionPaste uses `bg-accent/20 text-accent hover:bg-accent/30` — a ghost-accent variant that doesn't match any of the 3 button patterns defined in design-system.md § Buttons: "Every button in the editor must be one of these." As the primary action of this panel it should use the Primary pattern: `bg-accent text-white hover:bg-accent/80 transition-colors`.
+- **Files:** `src/components/editor/AddSectionPaste.tsx:195`
+- **Test:** Check "Structure with AI" button — must have `bg-accent text-white hover:bg-accent/80` classes, not `bg-accent/20 text-accent`
+- **Priority:** 1
+- **Tier:** 1
+- **Status:** OPEN
+
+### QR-27: Non-standard border-accent/40 in AddSectionUpload processing state
+- **What:** The upload drop zone uses `border-accent/40` in its processing state (`AddSectionUpload.tsx:379`). The design system border system defines only `border-accent/30` (soft focus ring) and `border-accent/50` (focus ring on inputs). `/40` is an undocumented intermediate value. Normalize to `border-accent/30` — a passive processing indicator doesn't need stronger emphasis than a soft focus ring.
+- **Files:** `src/components/editor/AddSectionUpload.tsx:379`
+- **Test:** `grep "border-accent/40" src/components/` — must return 0 matches
+- **Priority:** 1
+- **Tier:** 0
+- **Status:** OPEN
+
 ---
 
 ## Priority 2: Interaction Completeness (4-state rule)


### PR DESCRIPTION
Discovery agent visual consistency sweep on 2026-04-15.

Filed 3 new items:
- **QR-25 (Regression/Tier 0):** `text-[9px]` persists in `EditableSectionRenderer.tsx:960` and `GuidedJourney.tsx:350` — regression from QR-01 (kill-list item, normalize to `text-[10px]`)
- **QR-26 (Tier 1):** Non-standard ghost-accent button in `AddSectionPaste.tsx:195` — `bg-accent/20 text-accent hover:bg-accent/30` doesn't match any of the 3 design-system button patterns; primary action should use `bg-accent text-white hover:bg-accent/80`
- **QR-27 (Tier 0):** `border-accent/40` in `AddSectionUpload.tsx:379` — non-standard border opacity (system defines `/30` and `/50`); normalize to `border-accent/30`

No source files touched. Rubric + discovery logs only.
Review at leisure — Tier 0 is risk-free.