### PR TITLE
QR-15: Add aria-label to icon-only buttons in SortableSectionList

### DIFF
--- a/docs/agents/coordination-log.md
+++ b/docs/agents/coordination-log.md
@@ -2,7 +2,7 @@
 
 
 ## 2026-04-16
-- 14:00 | quality | QR-15: Add aria-label to InsertDivider Plus and GripVertical drag handle in SortableSectionList | PR #199 | tier-0
+- 14:00 | quality | QR-15: Add aria-label to InsertDivider Plus and GripVertical drag handle in SortableSectionList | PR #202 | tier-0
 - 08:11 | vqa | VQS Report → docs/vqa/2026-04-16.md (0 regressions, 2 failures, 11 sections scored, avg VQS 78)
 
 - 08:05 | vqa | VQS Report → docs/vqa/2026-04-16.md (0 regressions, 0 failures, 8 sections scored, avg VQS 86)

--- a/docs/agents/coordination-log.md
+++ b/docs/agents/coordination-log.md
@@ -1,5 +1,12 @@
 # Agent Coordination Log
 
+
+## 2026-04-16
+- 14:00 | quality | QR-15: Add aria-label to InsertDivider Plus and GripVertical drag handle in SortableSectionList | PR #199 | tier-0
+- 08:11 | vqa | VQS Report → docs/vqa/2026-04-16.md (0 regressions, 2 failures, 11 sections scored, avg VQS 78)
+
+- 08:05 | vqa | VQS Report → docs/vqa/2026-04-16.md (0 regressions, 0 failures, 8 sections scored, avg VQS 86)
+
 ## 2026-04-15
 
 - 08:00 | quality | PR #195 | disc | tier-0 | open | Normalize font-semibold/tracking-widest/text-[9px]/text-[11px]/p-5 in FlywheelDiagram.tsx (newly-added section type missed by audit)

--- a/docs/agents/quality/scratchpad.md
+++ b/docs/agents/quality/scratchpad.md
@@ -10,6 +10,11 @@ Working through Tier 1 items in `docs/quality-rubric.md`. Next unblocked item af
 
 *(Patterns that worked. Append newest at top.)*
 
+### 2026-04-16 — Twenty-fourth run: QR-15 final close
+- QR-15 audit: SortableSectionList.tsx had 2 remaining icon-only buttons without aria-label: InsertDivider Plus button (line 52) and GripVertical drag handle (line 114).
+- The rubric's heuristic test (`grep className=.*w-[34].*h-[34] | grep <button`) returned 0 results because these buttons have `w-5 h-5` or no size class on the button itself — the icons inside them carry the size class. Test heuristic can miss violations where the button is not sized with w-3/w-4.
+- Rule: for icon-only audits, also manually check buttons whose className doesn't contain `w-3`/`w-4` but which have no visible text content.
+
 ### 2026-04-15 — Twenty-third run: 2 PRs (both Tier 0), discovery on newly-added section types
 - All rubric items closed or Tier 3 blocked. Went straight to discovery.
 - New pattern: when new viewer section types are added (d6815eb added FlywheelDiagram, ComparisonMatrix, HeroStats, CallToAction), they bypass the quality rubric history and need immediate audit.

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -98,7 +98,7 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 - **What:** Every button that contains only an icon (no text) must have `aria-label`. Audit all editor components.
 - **Files:** All files in `src/components/editor/`
 - **Test:** `grep -r "className=.*w-[34].*h-[34]" src/components/editor/ | grep "<button"` — every match has `aria-label`
-- **Status:** DONE (2026-04-16, PR #199)
+- **Status:** DONE (2026-04-16, PR #202)
 
 ---
 

--- a/docs/quality-rubric.md
+++ b/docs/quality-rubric.md
@@ -93,12 +93,12 @@ Every rubric item has a **Tier** (0-3) that determines how its PR is handled:
 ### ~~QR-14: ARIA live regions for dynamic content~~ DONE
 - **Status:** DONE — PR #QR-14. Added `aria-live="polite"` to save status in TopBar, message list in AiChatPanel, and all 6 error message containers in editor components.
 
-### QR-15: ARIA labels on all icon-only buttons
+### ~~QR-15: ARIA labels on all icon-only buttons~~ DONE
 - **Tier:** 0
 - **What:** Every button that contains only an icon (no text) must have `aria-label`. Audit all editor components.
 - **Files:** All files in `src/components/editor/`
 - **Test:** `grep -r "className=.*w-[34].*h-[34]" src/components/editor/ | grep "<button"` — every match has `aria-label`
-- **Status:** OPEN
+- **Status:** DONE (2026-04-16, PR #199)
 
 ---
 

--- a/src/components/editor/SortableSectionList.tsx
+++ b/src/components/editor/SortableSectionList.tsx
@@ -51,6 +51,7 @@ function InsertDivider({ onClick }: { onClick: () => void }) {
       <div className="absolute inset-x-3 h-px bg-transparent group-hover/insert:bg-accent/40 transition-colors" />
       <button
         onClick={onClick}
+        aria-label="Insert section here"
         className="relative mx-auto flex items-center justify-center w-5 h-5 rounded-full border border-transparent text-transparent group-hover/insert:border-accent/40 group-hover/insert:text-accent/70 hover:!border-accent hover:!text-accent hover:!bg-accent/10 transition-all"
       >
         <Plus className="w-3 h-3" />
@@ -114,6 +115,7 @@ function SortableItem({
       <button
         {...attributes}
         {...listeners}
+        aria-label="Drag to reorder"
         className="opacity-0 group-hover:opacity-50 shrink-0 cursor-grab touch-none transition-opacity"
       >
         <GripVertical className="w-3.5 h-3.5" />


### PR DESCRIPTION
## What
Two icon-only buttons in `SortableSectionList.tsx` were missing `aria-label`:
1. The `InsertDivider` Plus button (hover-to-reveal insert between sections)
2. The `GripVertical` drag handle on each section row

Both buttons contain only an icon with no visible text, making them inaccessible to screen readers.

## Why
Quality rubric item QR-15: ARIA labels on all icon-only buttons
Design system reference: Accessibility — every interactive element must have an accessible name

## Files changed
- `src/components/editor/SortableSectionList.tsx` (+2 aria-label attributes)
- `docs/quality-rubric.md` (QR-15 marked DONE)
- `docs/agents/coordination-log.md`
- `docs/agents/quality/scratchpad.md`

## Visual Quality Score
VQS: not measured — ARIA attributes are not visual and have no effect on rendered appearance

## Test
```
grep -n "aria-label" src/components/editor/SortableSectionList.tsx
```
Expected output includes:
- `aria-label="Insert section here"` on InsertDivider button
- `aria-label="Drag to reorder"` on GripVertical button

Build passes: ✓